### PR TITLE
build: integrate ngtcp2 submodule with GnuTLS using static linking.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,7 @@
 [submodule "dpdk"]
 	path = dpdk
 	url = ../dpdk
+	
+[submodule "ngtcp2"]
+	path = ngtcp2
+	url = https://github.com/TusikNusik/ngtcp2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -384,6 +384,7 @@ find_package (ragel 6.10 REQUIRED)
 find_package (Threads REQUIRED)
 find_package (PthreadSetName REQUIRED)
 find_package (Valgrind REQUIRED)
+find_package (ngtcp2 REQUIRED)
 
 cmake_dependent_option (Seastar_LOGGER_COMPILE_TIME_FMT
   "Enable the compile-time {fmt} check when formatting logging messages" ON
@@ -847,6 +848,7 @@ target_link_libraries (seastar
     lz4::lz4
   PRIVATE
     ${CMAKE_DL_LIBS}
+    ngtcp2::ngtcp2
     GnuTLS::gnutls
     StdAtomic::atomic
     lksctp-tools::lksctp-tools

--- a/cmake/Findngtcp2.cmake
+++ b/cmake/Findngtcp2.cmake
@@ -1,0 +1,79 @@
+set (NGTCP2_ENABLE_LIB_ONLY    
+  ON  
+  CACHE 
+  BOOL 
+  "Build libngtcp2 only")
+
+set (NGTCP2_ENABLE_STATIC_LIB  
+  ON  
+  CACHE 
+  BOOL 
+  "Build static lib")
+
+set (NGTCP2_ENABLE_SHARED_LIB  
+  OFF 
+  CACHE 
+  BOOL 
+  "Disable shared lib")
+
+set (NGTCP2_ENABLE_GNUTLS      
+  ON  
+  CACHE 
+  BOOL 
+  "Enable GnuTLS")
+
+set (NGTCP2_ENABLE_OPENSSL     
+  OFF 
+  CACHE 
+  BOOL 
+  "Disable OpenSSL")
+
+set (NGTCP2_DISABLE_TESTS      
+  ON
+  CACHE
+  BOOL 
+  "Disable tests")
+
+add_subdirectory (ngtcp2)
+
+set (NGTCP2_SRC "${CMAKE_CURRENT_SOURCE_DIR}/ngtcp2")
+set (NGTCP2_BIN "${CMAKE_CURRENT_BINARY_DIR}/ngtcp2")
+
+set (ngtcp2_INCLUDE_DIRS
+  "${NGTCP2_SRC}/lib/includes"     
+  "${NGTCP2_SRC}/crypto/includes"  
+  "${NGTCP2_SRC}/lib"              
+  "${NGTCP2_BIN}/lib/includes"     
+)
+
+if (TARGET ngtcp2_static AND TARGET ngtcp2_crypto_gnutls_static)
+  add_library (ngtcp2::ngtcp2 INTERFACE IMPORTED)
+
+  set_target_properties(ngtcp2_static PROPERTIES 
+    POSITION_INDEPENDENT_CODE ON
+  )
+  
+  set_target_properties(ngtcp2_crypto_gnutls_static PROPERTIES
+    POSITION_INDEPENDENT_CODE ON
+  )
+
+  set_target_properties (ngtcp2::ngtcp2 PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES "${ngtcp2_INCLUDE_DIRS}"
+  )
+
+  target_link_libraries(ngtcp2::ngtcp2
+    INTERFACE
+      ngtcp2_static
+      ngtcp2_crypto_gnutls_static
+  )
+
+  set (ngtcp2_FOUND TRUE)
+else()
+  message (FATAL_ERROR "[ngtcp2] CRITICAL: targets of ngtcp2 library haven't been found!")
+endif()
+
+include (FindPackageHandleStandardArgs)
+
+find_package_handle_standard_args (ngtcp2 
+  REQUIRED_VARS 
+    ngtcp2_FOUND)


### PR DESCRIPTION
Introduced ngtcp2 quic library as the git submodule located in external folder. Forced static library generation with GnuTLS in CMake configuration. Added submodule via subdirectory and aliased main targets. Added necessary include directories for seastar target. Linked seastar against ngtcp2 static library files. In install_dependencies.sh enforced updating ngtcp2 submodule.