### PR TITLE
RPC on QUIC implementation.

### DIFF
--- a/.github/workflows/alpinelinux.yaml
+++ b/.github/workflows/alpinelinux.yaml
@@ -23,6 +23,9 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
 
+    - name: Mark workspace safe for git
+      run: git config --global --add safe.directory '*'
+
     - name: Checkout ngtcp2 submodule
       run: git submodule update --init ngtcp2
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -801,6 +801,7 @@ add_library (seastar
   src/rpc/lz4_compressor.cc
   src/rpc/lz4_fragmented_compressor.cc
   src/rpc/rpc.cc
+  src/rpc/rpc_quic_transport.cc
   src/util/alloc_failure_injector.cc
   src/util/backtrace.cc
   src/util/conversions.cc

--- a/demos/CMakeLists.txt
+++ b/demos/CMakeLists.txt
@@ -132,6 +132,9 @@ seastar_add_demo (quic_server
 seastar_add_demo (quic_client
   SOURCES quic_client_demo.cc)
 
+seastar_add_demo (rpc_quic
+  SOURCES rpc_quic_demo.cc)
+
 if (Seastar_MODULE)
   add_executable (hello_cxx_module)
   target_sources (hello_cxx_module

--- a/demos/CMakeLists.txt
+++ b/demos/CMakeLists.txt
@@ -132,6 +132,18 @@ seastar_add_demo (quic_server
 seastar_add_demo (quic_client
   SOURCES quic_client_demo.cc)
 
+seastar_add_demo (quic_bench_server
+  SOURCES benchmarks/quic_bench_server.cc)
+
+seastar_add_demo (quic_bench_client
+  SOURCES benchmarks/quic_bench_client.cc)
+
+seastar_add_demo (rpc_quic_bench_server
+  SOURCES benchmarks/rpc_quic_bench_server.cc)
+
+seastar_add_demo (rpc_quic_bench_client
+  SOURCES benchmarks/rpc_quic_bench_client.cc)
+
 seastar_add_demo (rpc_quic
   SOURCES rpc_quic_demo.cc)
 

--- a/demos/benchmarks/quic_bench_client.cc
+++ b/demos/benchmarks/quic_bench_client.cc
@@ -1,0 +1,571 @@
+/*
+ * This file is open source software, licensed to you under the terms
+ * of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.  You may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Copyright (C) 2026 ScyllaDB Ltd.
+ */
+
+// QUIC benchmark client.
+//
+// Two benchmark modes (--mode):
+//
+//   throughput  Opens --connections connections, each with --streams-per-conn
+//               streams.  Each stream sends --message-size byte messages as
+//               fast as possible for --duration seconds, then closes.
+//               Supports both --stream-type bidi (server echoes, RX measured)
+//               and --stream-type uni (server discards, TX only measured).
+//
+//   latency     Opens --connections connections, each with --streams-per-conn
+//               bidirectional streams.  Each stream performs sequential
+//               ping-pong: send --message-size bytes, await echo, record RTT.
+//               Reports p50/p95/p99/p99.9/max/mean RTT at the end.
+//               Only --stream-type bidi is supported in this mode.
+//
+// Run quic_bench_server on the other end before starting this client.
+
+#include <arpa/inet.h>
+
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <exception>
+#include <iostream>
+#include <numeric>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <fmt/core.h>
+
+#include <seastar/core/app-template.hh>
+#include <seastar/core/coroutine.hh>
+#include <seastar/core/future.hh>
+#include <seastar/core/reactor.hh>
+#include <seastar/core/shared_ptr.hh>
+#include <seastar/core/when_all.hh>
+#include <seastar/quic/quic_client.hh>
+
+using namespace seastar;
+using namespace seastar::quic::experimental;
+namespace bpo = boost::program_options;
+
+using bm_clock   = std::chrono::steady_clock;
+using time_point = bm_clock::time_point;
+using us_t       = std::chrono::microseconds;
+
+static constexpr size_t throughput_buffer_size = 256 * 1024;
+static constexpr uint64_t throughput_stream_window = 8 * 1024 * 1024;
+static constexpr uint64_t throughput_connection_window = 64 * 1024 * 1024;
+static constexpr uint64_t throughput_stream_limit = 1024;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+static socket_address parse_ipv6_address(const std::string& ip, uint16_t port) {
+    sockaddr_in6 sa{};
+    sa.sin6_family = AF_INET6;
+    sa.sin6_port = htons(port);
+    if (inet_pton(AF_INET6, ip.c_str(), &sa.sin6_addr) != 1) {
+        throw std::runtime_error("Invalid IPv6 address: " + ip);
+    }
+    return socket_address(sa);
+}
+
+static stream_type parse_stream_type(const std::string& s) {
+    if (s == "bidi") { return stream_type::bidirectional; }
+    if (s == "uni")  { return stream_type::unidirectional; }
+    throw std::runtime_error("Unknown stream-type '" + s + "': expected bidi or uni");
+}
+
+static size_t resolve_throughput_flush_messages(size_t configured, size_t msg_size) {
+    if (configured > 0) {
+        return configured;
+    }
+    return std::max<size_t>(1, throughput_buffer_size / std::max<size_t>(msg_size, 1));
+}
+
+// ---------------------------------------------------------------------------
+// Shared result accumulators (single-shard: no atomics needed)
+// ---------------------------------------------------------------------------
+
+struct throughput_result {
+    uint64_t bytes_sent     = 0;
+    uint64_t bytes_received = 0;  // meaningful only for bidi
+    uint64_t messages_sent  = 0;
+};
+
+// All latency samples in microseconds, collected across all streams.
+using latency_samples = std::vector<int64_t>;
+
+// ---------------------------------------------------------------------------
+// Per-stream benchmark coroutines
+// ---------------------------------------------------------------------------
+
+// Throughput: bidirectional stream.
+// Sends as fast as possible until `deadline`; drains the echo concurrently.
+static future<> run_bidi_throughput_stream(
+        lw_shared_ptr<connection> conn,
+        const std::vector<char>&  msg,
+        time_point                deadline,
+        size_t                    flush_messages,
+        throughput_result&        result) {
+
+    auto s   = co_await conn->open_stream({.type = stream_type::bidirectional});
+    auto inp = make_lw_shared<input_stream<char>>(s.input());
+    // Match the TLS/TCP benchmark buffering in throughput mode.
+    auto out = make_lw_shared<output_stream<char>>(s.output(throughput_buffer_size));
+    auto bytes_rx = make_lw_shared<uint64_t>(0);
+    auto bytes_tx = make_lw_shared<uint64_t>(0);
+    auto msgs_tx  = make_lw_shared<uint64_t>(0);
+
+    // Sender: write until deadline, then close the output half.
+    auto sender = [out, bytes_tx, msgs_tx, deadline,
+                   data = msg.data(), sz = msg.size(), flush_messages]() -> future<> {
+        size_t pending_messages = 0;
+        while (bm_clock::now() < deadline) {
+            co_await out->write(data, sz);
+            *bytes_tx += sz;
+            ++(*msgs_tx);
+            ++pending_messages;
+            if (pending_messages >= flush_messages) {
+                co_await out->flush();
+                pending_messages = 0;
+            }
+        }
+        if (pending_messages > 0) {
+            co_await out->flush();
+        }
+        co_await out->close();
+    };
+
+    // Receiver: drain until server closes its end (after echoing everything).
+    auto receiver = [inp, bytes_rx]() -> future<> {
+        while (true) {
+            auto buf = co_await inp->read();
+            if (buf.empty()) { co_return; }
+            *bytes_rx += buf.size();
+        }
+    };
+
+    try {
+        co_await when_all_succeed(sender(), receiver()).discard_result();
+    } catch (const quic_error& e) {
+        if (e.code() != quic_error::closed) { throw; }
+    }
+
+    result.bytes_sent     += *bytes_tx;
+    result.bytes_received += *bytes_rx;
+    result.messages_sent  += *msgs_tx;
+}
+
+// Throughput: unidirectional stream (client->server only).
+// The server discards data; only TX throughput is measured.
+static future<> run_uni_throughput_stream(
+        lw_shared_ptr<connection> conn,
+        const std::vector<char>&  msg,
+        time_point                deadline,
+        size_t                    flush_messages,
+        throughput_result&        result) {
+
+    auto s   = co_await conn->open_stream({.type = stream_type::unidirectional});
+    auto out = s.output(throughput_buffer_size);
+    try {
+        size_t pending_messages = 0;
+        while (bm_clock::now() < deadline) {
+            co_await out.write(msg.data(), msg.size());
+            result.bytes_sent += msg.size();
+            ++result.messages_sent;
+            ++pending_messages;
+            if (pending_messages >= flush_messages) {
+                co_await out.flush();
+                pending_messages = 0;
+            }
+        }
+        if (pending_messages > 0) {
+            co_await out.flush();
+        }
+        co_await out.close();
+    } catch (const quic_error& e) {
+        if (e.code() != quic_error::closed) { throw; }
+    }
+}
+
+// Latency: bidirectional ping-pong on a single stream.
+// Sends one message, waits for the full echo, records RTT.  Repeats until
+// `deadline`.  Appends microsecond RTT values to `samples`.
+static future<> run_latency_stream(
+        lw_shared_ptr<connection> conn,
+        const std::vector<char>&  msg,
+        time_point                deadline,
+        latency_samples&          samples) {
+
+    auto s        = co_await conn->open_stream({.type = stream_type::bidirectional});
+    auto inp      = s.input();
+    auto out      = s.output();
+    const size_t msg_size = msg.size();
+
+    try {
+        while (bm_clock::now() < deadline) {
+            auto t0 = bm_clock::now();
+
+            co_await out.write(msg.data(), msg_size);
+            co_await out.flush();
+
+            // Receive exactly msg_size bytes (echo may arrive in fragments).
+            size_t received = 0;
+            bool eof        = false;
+            while (received < msg_size && !eof) {
+                auto buf = co_await inp.read();
+                if (buf.empty()) {
+                    eof = true;
+                    break;
+                }
+                received += buf.size();
+            }
+            if (eof) { break; }
+
+            auto rtt_us = std::chrono::duration_cast<us_t>(bm_clock::now() - t0).count();
+            samples.push_back(rtt_us);
+        }
+        co_await out.close();
+        co_await inp.close();
+    } catch (const quic_error& e) {
+        if (e.code() != quic_error::closed) { throw; }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Per-connection runners
+// ---------------------------------------------------------------------------
+
+static future<> run_connection_throughput(
+        quic_client_config       cfg,
+        int                      n_streams,
+        stream_type              stype,
+        const std::vector<char>& msg,
+        time_point               deadline,
+        size_t                   flush_messages,
+        throughput_result&       result) {
+
+    quic_client client;
+    std::exception_ptr err;
+    try {
+        auto conn = make_lw_shared<connection>(co_await client.connect(cfg));
+
+        std::vector<future<>> futs;
+        futs.reserve(n_streams);
+        for (int i = 0; i < n_streams; ++i) {
+            if (stype == stream_type::bidirectional) {
+                futs.push_back(run_bidi_throughput_stream(conn, msg, deadline, flush_messages, result));
+            } else {
+                futs.push_back(run_uni_throughput_stream(conn, msg, deadline, flush_messages, result));
+            }
+        }
+
+        auto stream_results = co_await when_all(futs.begin(), futs.end());
+        for (auto& f : stream_results) {
+            try { f.get(); }
+            catch (const std::exception& e) {
+                std::cerr << "[client] stream error: " << e.what() << "\n";
+            }
+        }
+
+        try { co_await conn->close(); } catch (...) {}
+    } catch (...) {
+        err = std::current_exception();
+    }
+    try { co_await client.stop(); } catch (...) {}
+    if (err) { std::rethrow_exception(err); }
+}
+
+static future<> run_connection_latency(
+        quic_client_config       cfg,
+        int                      n_streams,
+        const std::vector<char>& msg,
+        time_point               deadline,
+        latency_samples&         samples) {
+
+    quic_client client;
+    std::exception_ptr err;
+    try {
+        auto conn = make_lw_shared<connection>(co_await client.connect(cfg));
+
+        std::vector<future<>> futs;
+        futs.reserve(n_streams);
+        for (int i = 0; i < n_streams; ++i) {
+            futs.push_back(run_latency_stream(conn, msg, deadline, samples));
+        }
+
+        auto stream_results = co_await when_all(futs.begin(), futs.end());
+        for (auto& f : stream_results) {
+            try { f.get(); }
+            catch (const std::exception& e) {
+                std::cerr << "[client] stream error: " << e.what() << "\n";
+            }
+        }
+
+        try { co_await conn->close(); } catch (...) {}
+    } catch (...) {
+        err = std::current_exception();
+    }
+    try { co_await client.stop(); } catch (...) {}
+    if (err) { std::rethrow_exception(err); }
+}
+
+// ---------------------------------------------------------------------------
+// Statistics printers
+// ---------------------------------------------------------------------------
+
+static void print_throughput(
+        const throughput_result& r,
+        double                   elapsed_s,
+        stream_type              stype,
+        int                      n_conns,
+        int                      n_streams_per_conn,
+        size_t                   msg_size) {
+
+    fmt::print("\n=== QUIC Throughput Benchmark: {} streams ===\n",
+        stype == stream_type::bidirectional ? "bidirectional" : "unidirectional");
+    fmt::print("  Connections: {}  Streams/conn: {}  Msg size: {} B  Elapsed: {:.2f} s\n",
+        n_conns, n_streams_per_conn, msg_size, elapsed_s);
+    fmt::print("  TX: {} bytes  ({:.2f} MB/s,  {:.0f} msg/s)\n",
+        r.bytes_sent,
+        r.bytes_sent  / 1e6 / elapsed_s,
+        r.messages_sent / elapsed_s);
+    if (stype == stream_type::bidirectional) {
+        fmt::print("  RX: {} bytes  ({:.2f} MB/s)\n",
+            r.bytes_received,
+            r.bytes_received / 1e6 / elapsed_s);
+    }
+    fmt::print("\n");
+    std::cout.flush();
+}
+
+static void print_latency(
+        const latency_samples& raw_samples,
+        double                 elapsed_s,
+        stream_type            stype,
+        int                    n_conns,
+        int                    n_streams_per_conn,
+        size_t                 msg_size) {
+
+    fmt::print("\n=== QUIC Latency Benchmark: {} streams ===\n",
+        stype == stream_type::bidirectional ? "bidirectional" : "unidirectional");
+    fmt::print("  Connections: {}  Streams/conn: {}  Msg size: {} B  Elapsed: {:.2f} s\n",
+        n_conns, n_streams_per_conn, msg_size, elapsed_s);
+
+    if (raw_samples.empty()) {
+        fmt::print("  No samples collected.\n\n");
+        std::cout.flush();
+        return;
+    }
+
+    auto samples = raw_samples;
+    std::sort(samples.begin(), samples.end());
+    const size_t count = samples.size();
+
+    auto percentile_ms = [&](double p) -> double {
+        size_t idx = static_cast<size_t>(p / 100.0 * static_cast<double>(count));
+        if (idx >= count) { idx = count - 1; }
+        return static_cast<double>(samples[idx]) / 1000.0;  // us -> ms
+    };
+
+    double mean_ms = static_cast<double>(
+        std::accumulate(samples.begin(), samples.end(), int64_t{0}))
+        / static_cast<double>(count) / 1000.0;
+
+    fmt::print("  Samples:  {}\n",   count);
+    fmt::print("  mean:     {:.3f} ms\n", mean_ms);
+    fmt::print("  p50:      {:.3f} ms\n", percentile_ms(50));
+    fmt::print("  p95:      {:.3f} ms\n", percentile_ms(95));
+    fmt::print("  p99:      {:.3f} ms\n", percentile_ms(99));
+    fmt::print("  p99.9:    {:.3f} ms\n", percentile_ms(99.9));
+    fmt::print("  max:      {:.3f} ms\n", static_cast<double>(samples.back()) / 1000.0);
+    fmt::print("\n");
+    std::cout.flush();
+}
+
+// ---------------------------------------------------------------------------
+// main
+// ---------------------------------------------------------------------------
+
+int main(int argc, char** argv) {
+    app_template app;
+    app.add_options()
+        ("address", bpo::value<std::string>()->default_value("::1"),
+         "Server IPv6 address")
+        ("port", bpo::value<uint16_t>()->default_value(4444),
+         "Server UDP port")
+        ("server-name", bpo::value<std::string>()->default_value("localhost"),
+         "TLS server name (SNI)")
+        ("ca", bpo::value<std::string>()->default_value("server.crt"),
+         "PEM CA/certificate file used to verify the server")
+        ("mode", bpo::value<std::string>()->default_value("throughput"),
+         "Benchmark mode: throughput or latency")
+        ("stream-type", bpo::value<std::string>()->default_value("bidi"),
+         "QUIC stream type: bidi (bidirectional) or uni (unidirectional, throughput only)")
+        ("connections", bpo::value<int>()->default_value(1),
+         "Number of parallel connections")
+        ("streams-per-conn", bpo::value<int>()->default_value(1),
+         "Number of concurrent streams per connection")
+        ("message-size", bpo::value<size_t>()->default_value(65536),
+         "Size of each message in bytes (throughput default: 64 KiB)")
+        ("throughput-flush-messages", bpo::value<size_t>()->default_value(0),
+         "Flush throughput output every N messages (0 = auto, about one output buffer)")
+        ("duration", bpo::value<unsigned>()->default_value(10),
+         "Benchmark duration in seconds");
+
+    return app.run(argc, argv, [&app]() -> future<int> {
+        std::exception_ptr error;
+        try {
+            auto&& cfg       = app.configuration();
+            auto address     = cfg["address"].as<std::string>();
+            auto port        = cfg["port"].as<uint16_t>();
+            auto server_name = cfg["server-name"].as<std::string>();
+            auto ca_file     = cfg["ca"].as<std::string>();
+            auto mode        = cfg["mode"].as<std::string>();
+            auto stype       = parse_stream_type(cfg["stream-type"].as<std::string>());
+            auto n_conns     = cfg["connections"].as<int>();
+            auto n_streams   = cfg["streams-per-conn"].as<int>();
+            auto msg_size    = cfg["message-size"].as<size_t>();
+            auto flush_messages_cfg = cfg["throughput-flush-messages"].as<size_t>();
+            auto dur_s       = cfg["duration"].as<unsigned>();
+
+            if (mode != "throughput" && mode != "latency") {
+                throw std::runtime_error(
+                    "Unknown mode '" + mode + "': expected throughput or latency");
+            }
+            if (mode == "latency" && stype != stream_type::bidirectional) {
+                throw std::runtime_error("Latency mode requires --stream-type bidi");
+            }
+            if (n_conns < 1 || n_streams < 1) {
+                throw std::runtime_error(
+                    "--connections and --streams-per-conn must be >= 1");
+            }
+            if (msg_size < 1) {
+                throw std::runtime_error("--message-size must be >= 1");
+            }
+
+            // Build the message payload once (filled with 'Q').
+            const std::vector<char> msg(msg_size, 'Q');
+            const auto flush_messages = resolve_throughput_flush_messages(flush_messages_cfg, msg_size);
+
+            // Base client config - each connection gets its own quic_client.
+            quic_client_config base_cfg;
+            base_cfg.remote_address = parse_ipv6_address(address, port);
+            base_cfg.server_name    = server_name;
+            if (!ca_file.empty()) {
+                base_cfg.ca_file = ca_file;
+            }
+            // Transport limits tuned for the actor-based transport engine.
+            base_cfg.session_options.max_pending_send_bytes    = 4 * 1024 * 1024;
+            base_cfg.session_options.max_pending_receive_bytes = 64 * 1024 * 1024;
+            base_cfg.session_options.transport.initial_max_stream_data_bidi_local  = throughput_stream_window;
+            base_cfg.session_options.transport.initial_max_stream_data_bidi_remote = throughput_stream_window;
+            base_cfg.session_options.transport.initial_max_stream_data_uni         = throughput_stream_window;
+            base_cfg.session_options.transport.initial_max_data         = throughput_connection_window;
+            base_cfg.session_options.transport.initial_max_streams_bidi = throughput_stream_limit;
+            base_cfg.session_options.transport.initial_max_streams_uni  = throughput_stream_limit;
+            base_cfg.session_options.transport.max_window = throughput_connection_window;
+            base_cfg.session_options.transport.max_stream_window = 16 * 1024 * 1024;
+            base_cfg.session_options.transport.ack_thresh = 8;
+            base_cfg.session_options.transport.initial_rtt_ns = 0;
+            base_cfg.session_options.transport.congestion_control = congestion_control_algorithm::bbr;
+            base_cfg.session_options.transport.max_udp_payload_size = 65527;
+            base_cfg.session_options.transport.max_tx_udp_payload_size = 4096;
+            base_cfg.session_options.transport.disable_tx_udp_payload_size_shaping = true;
+
+            const auto deadline = bm_clock::now() + std::chrono::seconds(dur_s);
+
+            fmt::print(
+                "[client] mode={} stream-type={} conns={} streams/conn={} msg={}B dur={}s flush-msgs={}\n",
+                mode,
+                stype == stream_type::bidirectional ? "bidi" : "uni",
+                n_conns, n_streams, msg_size, dur_s, flush_messages);
+            std::cout.flush();
+
+            // ------------------------------------------------------------------
+            // Throughput benchmark
+            // ------------------------------------------------------------------
+            if (mode == "throughput") {
+                throughput_result total;
+                const auto bench_start = bm_clock::now();
+
+                std::vector<future<>> conn_futs;
+                conn_futs.reserve(n_conns);
+                for (int c = 0; c < n_conns; ++c) {
+                    conn_futs.push_back(
+                        run_connection_throughput(
+                            base_cfg, n_streams, stype, msg, deadline, flush_messages, total));
+                }
+
+                auto results = co_await when_all(conn_futs.begin(), conn_futs.end());
+                for (auto& f : results) {
+                    try {
+                        f.get();
+                    } catch (const std::exception& e) {
+                        std::cerr << "[client] connection error: " << e.what() << "\n";
+                    }
+                }
+
+                const auto elapsed = std::chrono::duration<double>(
+                    bm_clock::now() - bench_start).count();
+                print_throughput(total, elapsed, stype, n_conns, n_streams, msg_size);
+            } else {
+                latency_samples all_samples;
+                const auto bench_start = bm_clock::now();
+
+                std::vector<future<>> conn_futs;
+                conn_futs.reserve(n_conns);
+                for (int c = 0; c < n_conns; ++c) {
+                    conn_futs.push_back(
+                        run_connection_latency(base_cfg, n_streams, msg, deadline, all_samples));
+                }
+
+                auto results = co_await when_all(conn_futs.begin(), conn_futs.end());
+                for (auto& f : results) {
+                    try {
+                        f.get();
+                    } catch (const std::exception& e) {
+                        std::cerr << "[client] connection error: " << e.what() << "\n";
+                    }
+                }
+
+                const auto elapsed = std::chrono::duration<double>(
+                    bm_clock::now() - bench_start).count();
+                print_latency(all_samples, elapsed, stype, n_conns, n_streams, msg_size);
+            }
+        } catch (...) {
+            error = std::current_exception();
+        }
+
+        if (error) {
+            try {
+                std::rethrow_exception(error);
+            } catch (const std::exception& e) {
+                std::cerr << "[client] fatal: " << e.what() << "\n";
+            } catch (...) {
+                std::cerr << "[client] fatal: unknown exception\n";
+            }
+            co_return 1;
+        }
+
+        co_return 0;
+    });
+}

--- a/demos/benchmarks/quic_bench_server.cc
+++ b/demos/benchmarks/quic_bench_server.cc
@@ -1,0 +1,323 @@
+/*
+ * This file is open source software, licensed to you under the terms
+ * of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.  You may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Copyright (C) 2026 ScyllaDB Ltd.
+ */
+
+// QUIC benchmark server.
+//
+// For bidirectional streams: echoes all received data back to the client.
+// For unidirectional streams (client->server): reads and discards all data.
+//
+// Prints throughput statistics every --stats-interval seconds.
+// Use alongside quic_bench_client to measure QUIC throughput and latency.
+
+#include <arpa/inet.h>
+
+#include <cstdint>
+#include <exception>
+#include <iostream>
+#include <optional>
+#include <stdexcept>
+#include <string>
+
+#include <fmt/core.h>
+
+#include <seastar/core/abort_source.hh>
+#include <seastar/core/app-template.hh>
+#include <seastar/core/coroutine.hh>
+#include <seastar/core/gate.hh>
+#include <seastar/core/reactor.hh>
+#include <seastar/core/sleep.hh>
+#include <seastar/core/when_all.hh>
+#include <seastar/quic/quic_server.hh>
+
+#include "../../apps/lib/stop_signal.hh"
+
+using namespace seastar;
+using namespace seastar::quic::experimental;
+namespace bpo = boost::program_options;
+
+static constexpr size_t throughput_buffer_size = 256 * 1024;
+static constexpr uint64_t throughput_stream_window = 8 * 1024 * 1024;
+static constexpr uint64_t throughput_connection_window = 64 * 1024 * 1024;
+static constexpr uint64_t throughput_stream_limit = 1024;
+static size_t g_throughput_flush_bytes = throughput_buffer_size;
+
+static socket_address parse_ipv6_address(const std::string& ip, uint16_t port) {
+    sockaddr_in6 sa{};
+    sa.sin6_family = AF_INET6;
+    sa.sin6_port = htons(port);
+    if (inet_pton(AF_INET6, ip.c_str(), &sa.sin6_addr) != 1) {
+        throw std::runtime_error("Invalid IPv6 address: " + ip);
+    }
+    return socket_address(sa);
+}
+
+// Server-side counters (single-shard, no atomics needed).
+struct server_stats {
+    uint64_t bytes_received = 0;  // total bytes read from all streams
+    uint64_t bytes_echoed = 0;    // total bytes written back (bidi streams only)
+    uint64_t streams_completed = 0;
+    uint64_t connections_accepted = 0;
+};
+
+static server_stats g_stats;
+
+// Echo all data on a bidirectional stream.
+static future<> handle_bidi_stream(seastar::quic::experimental::stream s) {
+    auto input = s.input();
+    // Match the TLS/TCP benchmark buffering in throughput mode.
+    auto output = s.output(throughput_buffer_size);
+    size_t buffered_echo_bytes = 0;
+    try {
+        while (true) {
+            auto buf = co_await input.read();
+            if (buf.empty()) {
+                break;
+            }
+            g_stats.bytes_received += buf.size();
+            co_await output.write(buf.get(), buf.size());
+            buffered_echo_bytes += buf.size();
+            if (buffered_echo_bytes >= g_throughput_flush_bytes) {
+                co_await output.flush();
+                buffered_echo_bytes = 0;
+            }
+            g_stats.bytes_echoed += buf.size();
+        }
+        if (buffered_echo_bytes > 0) {
+            co_await output.flush();
+        }
+    } catch (const quic_error& e) {
+        if (e.code() != quic_error::closed) {
+            std::cerr << "[server] bidi stream error: " << e.what() << "\n";
+        }
+    }
+    try { co_await output.close(); } catch (...) {}
+    try { co_await input.close(); } catch (...) {}
+    ++g_stats.streams_completed;
+}
+
+// Drain all data on a unidirectional stream (client->server direction).
+static future<> handle_uni_stream(seastar::quic::experimental::stream s) {
+    auto input = s.input();
+    try {
+        while (true) {
+            auto buf = co_await input.read();
+            if (buf.empty()) {
+                break;
+            }
+            g_stats.bytes_received += buf.size();
+        }
+    } catch (const quic_error& e) {
+        if (e.code() != quic_error::closed) {
+            std::cerr << "[server] uni stream error: " << e.what() << "\n";
+        }
+    }
+    try { co_await input.close(); } catch (...) {}
+    ++g_stats.streams_completed;
+}
+
+static future<> handle_bench_stream(seastar::quic::experimental::stream s) {
+    if (s.type() == stream_type::bidirectional) {
+        return handle_bidi_stream(std::move(s));
+    } else {
+        return handle_uni_stream(std::move(s));
+    }
+}
+
+static future<> handle_bench_session(connection session) {
+    gate streams;
+    ++g_stats.connections_accepted;
+    try {
+        while (session.is_open()) {
+            auto s = co_await session.accept_stream();
+            (void)with_gate(streams, [s = std::move(s)]() mutable {
+                return handle_bench_stream(std::move(s));
+            }).handle_exception([](std::exception_ptr ep) {
+                try {
+                    std::rethrow_exception(ep);
+                } catch (const std::exception& e) {
+                    std::cerr << "[server] stream task failed: " << e.what() << "\n";
+                }
+            }).or_terminate();
+        }
+    } catch (const quic_error& e) {
+        if (e.code() != quic_error::closed) {
+            std::cerr << "[server] connection error: " << e.what() << "\n";
+        }
+    } catch (const std::exception& e) {
+        std::cerr << "[server] connection exception: " << e.what() << "\n";
+    }
+    try { co_await session.close(); } catch (...) {}
+    try { co_await streams.close(); } catch (...) {}
+}
+
+static future<> accept_loop(quic_server& server, gate& sessions) {
+    while (true) {
+        connection session;
+        try {
+            session = co_await server.accept();
+        } catch (const quic_error& e) {
+            if (e.code() == quic_error::closed) {
+                co_return;
+            }
+            throw;
+        }
+        (void)with_gate(sessions, [session = std::move(session)]() mutable {
+            return handle_bench_session(std::move(session));
+        }).handle_exception([](std::exception_ptr ep) {
+            try {
+                std::rethrow_exception(ep);
+            } catch (const std::exception& e) {
+                std::cerr << "[server] connection task failed: " << e.what() << "\n";
+            }
+        }).or_terminate();
+    }
+}
+
+// Prints a one-line stats summary every `interval_s` seconds until aborted.
+static future<> print_stats_loop(unsigned interval_s, abort_source& as) {
+    uint64_t prev_rx = 0;
+    uint64_t prev_tx = 0;
+    try {
+        while (true) {
+            co_await sleep_abortable(std::chrono::seconds(interval_s), as);
+            uint64_t rx = g_stats.bytes_received;
+            uint64_t tx = g_stats.bytes_echoed;
+            double rx_mb_s = static_cast<double>(rx - prev_rx) / 1e6 / interval_s;
+            double tx_mb_s = static_cast<double>(tx - prev_tx) / 1e6 / interval_s;
+            prev_rx = rx;
+            prev_tx = tx;
+            fmt::print(
+                "[server] conns={} streams_done={} rx={:.1f} MB/s tx={:.1f} MB/s\n",
+                g_stats.connections_accepted,
+                g_stats.streams_completed,
+                rx_mb_s,
+                tx_mb_s);
+            std::cout.flush();
+        }
+    } catch (const sleep_aborted&) {
+        // Normal shutdown path.
+    }
+}
+
+int main(int argc, char** argv) {
+    app_template app;
+    app.add_options()
+        ("address", bpo::value<std::string>()->default_value("::1"),
+         "Server IPv6 address")
+        ("port", bpo::value<uint16_t>()->default_value(4444),
+         "Server UDP port")
+        ("crt", bpo::value<std::string>()->default_value("server.crt"),
+         "PEM certificate file")
+        ("key,k", bpo::value<std::string>()->default_value("server.key"),
+         "PEM private-key file")
+        ("throughput-flush-bytes", bpo::value<size_t>()->default_value(0),
+         "Flush echoed throughput data every N bytes (0 = auto, one output buffer)")
+        ("stats-interval", bpo::value<unsigned>()->default_value(1),
+         "Throughput stats printing interval in seconds (0 to disable)");
+
+    return app.run(argc, argv, [&app]() -> future<int> {
+        quic_server server;
+        gate sessions;
+        abort_source stats_as;
+        std::optional<future<>> accept_task;
+        std::optional<future<>> stats_task;
+        std::exception_ptr error;
+
+        try {
+            auto&& cfg = app.configuration();
+            auto address       = cfg["address"].as<std::string>();
+            auto port          = cfg["port"].as<uint16_t>();
+            auto crt           = cfg["crt"].as<std::string>();
+            auto key           = cfg["key"].as<std::string>();
+            auto flush_bytes   = cfg["throughput-flush-bytes"].as<size_t>();
+            auto stats_intv    = cfg["stats-interval"].as<unsigned>();
+            g_throughput_flush_bytes = flush_bytes > 0 ? flush_bytes : throughput_buffer_size;
+
+            quic_server_config server_cfg;
+            server_cfg.listen_address = parse_ipv6_address(address, port);
+            server_cfg.crt_file = crt;
+            server_cfg.key_file = key;
+            // Increase transport limits for high-throughput benchmarking.
+            server_cfg.session_options.max_pending_send_bytes    = 4 * 1024 * 1024;
+            server_cfg.session_options.max_pending_receive_bytes = 64 * 1024 * 1024;
+            server_cfg.session_options.transport.initial_max_stream_data_bidi_local  = throughput_stream_window;
+            server_cfg.session_options.transport.initial_max_stream_data_bidi_remote = throughput_stream_window;
+            server_cfg.session_options.transport.initial_max_stream_data_uni         = throughput_stream_window;
+            server_cfg.session_options.transport.initial_max_data          = throughput_connection_window;
+            server_cfg.session_options.transport.initial_max_streams_bidi  = throughput_stream_limit;
+            server_cfg.session_options.transport.initial_max_streams_uni   = throughput_stream_limit;
+            server_cfg.session_options.transport.max_window = throughput_connection_window;
+            server_cfg.session_options.transport.max_stream_window = 16 * 1024 * 1024;
+            server_cfg.session_options.transport.ack_thresh = 8;
+            server_cfg.session_options.transport.initial_rtt_ns = 0;
+            server_cfg.session_options.transport.congestion_control = congestion_control_algorithm::bbr;
+            server_cfg.session_options.transport.max_udp_payload_size = 65527;
+            server_cfg.session_options.transport.max_tx_udp_payload_size = 4096;
+            server_cfg.session_options.transport.disable_tx_udp_payload_size_shaping = true;
+
+            co_await server.start(std::move(server_cfg));
+            accept_task.emplace(accept_loop(server, sessions));
+            if (stats_intv > 0) {
+                stats_task.emplace(print_stats_loop(stats_intv, stats_as));
+            }
+
+            fmt::print("[server] QUIC bench server listening on [{}]:{}\n", address, port);
+            fmt::print("[server] throughput flush-bytes={}\n", g_throughput_flush_bytes);
+            fmt::print("[server] Ctrl-C to stop.\n");
+            std::cout.flush();
+
+            seastar_apps_lib::stop_signal stop_signal;
+            co_await stop_signal.wait();
+            fmt::print("[server] shutting down...\n");
+            std::cout.flush();
+        } catch (...) {
+            error = std::current_exception();
+        }
+
+        stats_as.request_abort();
+        if (stats_task) {
+            try { co_await std::move(*stats_task); } catch (...) {}
+        }
+        try { co_await server.stop(); } catch (...) {}
+        if (accept_task) {
+            try {
+                co_await std::move(*accept_task);
+            } catch (...) {
+                if (!error) { error = std::current_exception(); }
+            }
+        }
+        try { co_await sessions.close(); } catch (...) {
+            if (!error) { error = std::current_exception(); }
+        }
+
+        if (error) {
+            try {
+                std::rethrow_exception(error);
+            } catch (const std::exception& e) {
+                std::cerr << "[server] fatal: " << e.what() << "\n";
+            } catch (...) {
+                std::cerr << "[server] fatal: unknown exception\n";
+            }
+            co_return 1;
+        }
+        co_return 0;
+    });
+}

--- a/demos/benchmarks/rpc_quic_bench_client.cc
+++ b/demos/benchmarks/rpc_quic_bench_client.cc
@@ -1,0 +1,532 @@
+/*
+ * This file is open source software, licensed to you under the terms
+ * of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.  You may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Copyright (C) 2026 ScyllaDB Ltd.
+ */
+
+// Integrated RPC-on-QUIC benchmark client.
+//
+// Same shape as ../../rpc-quic-transport/src/rpc_bench_client.cc, but uses the
+// QUIC-integrated RPC API (protocol::make_quic_client) from the
+// feature/quic-rpc-integration branch.
+//
+// Modes:
+//
+//   throughput  Opens --connections RPC clients. Each one fires --concurrency
+//               in-flight echo calls of size --message-size for --duration s.
+//               Only call-type=echo is supported here -- the integrated
+//               implementation is not yet stable for no_wait/discard.
+//
+//   latency     Sequential calls per worker, records per-call RTT and reports
+//               p50/p95/p99/p99.9/max/mean. Supports call-type echo or ping.
+//
+// No request cancellations are issued by the benchmark.
+
+#include <arpa/inet.h>
+
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <exception>
+#include <iostream>
+#include <numeric>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <fmt/core.h>
+
+#include <seastar/core/app-template.hh>
+#include <seastar/core/coroutine.hh>
+#include <seastar/core/future.hh>
+#include <seastar/core/reactor.hh>
+#include <seastar/core/shared_ptr.hh>
+#include <seastar/core/when_all.hh>
+#include <seastar/rpc/rpc.hh>
+#include <seastar/rpc/rpc_quic_transport.hh>
+#include <seastar/util/log.hh>
+
+using namespace seastar;
+namespace bpo = boost::program_options;
+
+using bm_clock   = std::chrono::steady_clock;
+using time_point = bm_clock::time_point;
+using us_t       = std::chrono::microseconds;
+
+// ---------------------------------------------------------------------------
+// Minimal serializer
+// ---------------------------------------------------------------------------
+
+struct serializer {};
+
+template <typename T, typename Output>
+inline void write_arithmetic_type(Output& out, T v) {
+    static_assert(std::is_arithmetic_v<T>, "must be arithmetic type");
+    return out.write(reinterpret_cast<const char*>(&v), sizeof(T));
+}
+
+template <typename T, typename Input>
+inline T read_arithmetic_type(Input& in) {
+    static_assert(std::is_arithmetic_v<T>, "must be arithmetic type");
+    T v;
+    in.read(reinterpret_cast<char*>(&v), sizeof(T));
+    return v;
+}
+
+template <typename Output>
+inline void write(serializer, Output& output, int32_t v)  { return write_arithmetic_type(output, v); }
+template <typename Output>
+inline void write(serializer, Output& output, uint32_t v) { return write_arithmetic_type(output, v); }
+template <typename Output>
+inline void write(serializer, Output& output, int64_t v)  { return write_arithmetic_type(output, v); }
+template <typename Output>
+inline void write(serializer, Output& output, uint64_t v) { return write_arithmetic_type(output, v); }
+template <typename Input>
+inline int32_t  read(serializer, Input& input, rpc::type<int32_t>)  { return read_arithmetic_type<int32_t>(input); }
+template <typename Input>
+inline uint32_t read(serializer, Input& input, rpc::type<uint32_t>) { return read_arithmetic_type<uint32_t>(input); }
+template <typename Input>
+inline int64_t  read(serializer, Input& input, rpc::type<int64_t>)  { return read_arithmetic_type<int64_t>(input); }
+template <typename Input>
+inline uint64_t read(serializer, Input& input, rpc::type<uint64_t>) { return read_arithmetic_type<uint64_t>(input); }
+
+template <typename Output>
+inline void write(serializer, Output& out, const sstring& v) {
+    write_arithmetic_type(out, uint32_t(v.size()));
+    out.write(v.c_str(), v.size());
+}
+template <typename Input>
+inline sstring read(serializer, Input& in, rpc::type<sstring>) {
+    auto size = read_arithmetic_type<uint32_t>(in);
+    sstring ret = uninitialized_string(size);
+    in.read(ret.data(), size);
+    return ret;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+static socket_address parse_ipv6_address(const std::string& ip, uint16_t port) {
+    sockaddr_in6 sa{};
+    sa.sin6_family = AF_INET6;
+    sa.sin6_port = htons(port);
+    if (inet_pton(AF_INET6, ip.c_str(), &sa.sin6_addr) != 1) {
+        throw std::runtime_error("Invalid IPv6 address: " + ip);
+    }
+    return socket_address(sa);
+}
+
+enum class call_type_t { echo, discard, ping };
+
+static call_type_t parse_call_type(const std::string& s) {
+    if (s == "echo") { return call_type_t::echo; }
+    if (s == "ping") { return call_type_t::ping; }
+    if (s == "discard") { return call_type_t::discard; }
+    throw std::runtime_error("Unknown call-type '" + s + "': expected echo or ping");
+}
+
+// ---------------------------------------------------------------------------
+// Result accumulators
+// ---------------------------------------------------------------------------
+
+struct throughput_result {
+    uint64_t   bytes_sent     = 0;
+    uint64_t   bytes_received = 0;
+    uint64_t   calls_done     = 0;
+    // When the last successful call returned. Used to compute "bench window"
+    // elapsed time excluding any teardown hang in client->stop(): integrated
+    // QUIC sometimes hangs ~60s on stop, which would otherwise make
+    // wall_clock_elapsed inflate and throughput appear collapsed.
+    time_point last_call_end{};
+};
+
+using latency_samples = std::vector<int64_t>;  // microseconds
+
+// ---------------------------------------------------------------------------
+// Workers
+// ---------------------------------------------------------------------------
+
+using rpc_proto = rpc::protocol<serializer>;
+
+template <typename CallFn>
+static future<> run_throughput_worker(
+        CallFn                       call_fn,
+        size_t                       msg_size,
+        time_point                   deadline,
+        throughput_result&           result) {
+    try {
+        while (bm_clock::now() < deadline) {
+            co_await call_fn();
+            const auto now = bm_clock::now();
+            result.bytes_sent     += msg_size;
+            result.bytes_received += msg_size;
+            ++result.calls_done;
+            if (now > result.last_call_end) {
+                result.last_call_end = now;
+            }
+        }
+    } catch (const std::exception& e) {
+        std::cerr << "[client] throughput worker error: " << e.what() << "\n";
+    }
+}
+
+template <typename CallFn>
+static future<> run_latency_worker(
+        CallFn                       call_fn,
+        time_point                   deadline,
+        latency_samples&             samples) {
+    try {
+        while (bm_clock::now() < deadline) {
+            auto t0 = bm_clock::now();
+            co_await call_fn();
+            auto rtt_us = std::chrono::duration_cast<us_t>(bm_clock::now() - t0).count();
+            samples.push_back(rtt_us);
+        }
+    } catch (const std::exception& e) {
+        std::cerr << "[client] latency worker error: " << e.what() << "\n";
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Per-connection runners
+// ---------------------------------------------------------------------------
+
+static future<> run_connection_throughput(
+        rpc_proto&                                proto,
+        quic::experimental::quic_client_config    qcfg,
+        int                                       concurrency,
+        call_type_t                               ctype,
+        const sstring&                            payload,
+        time_point                                deadline,
+        throughput_result&                        result) {
+
+    rpc::client_options co;
+    auto client = co_await proto.make_quic_client(co, std::move(qcfg));
+
+    auto echo = proto.make_client<sstring (sstring)>(1);
+    auto discard = proto.make_client<rpc::no_wait_type (sstring)>(2);
+    const size_t msg_size = payload.size();
+
+    std::vector<future<>> futs;
+    futs.reserve(concurrency);
+    for (int i = 0; i < concurrency; ++i) {
+        auto call_fn = [&, p = payload]() mutable {
+            return ctype == call_type_t::discard
+                ? discard(*client, p).discard_result()
+                : echo(*client, p).discard_result();
+        };
+        futs.push_back(run_throughput_worker(std::move(call_fn), msg_size, deadline, result));
+    }
+
+    auto worker_results = co_await when_all(futs.begin(), futs.end());
+    for (auto& f : worker_results) {
+        try { f.get(); }
+        catch (const std::exception& e) {
+            std::cerr << "[client] worker error: " << e.what() << "\n";
+        }
+    }
+    try { co_await client->stop(); } catch (...) {}
+}
+
+static future<> run_connection_latency(
+        rpc_proto&                                proto,
+        quic::experimental::quic_client_config    qcfg,
+        int                                       concurrency,
+        call_type_t                               ctype,
+        const sstring&                            payload,
+        time_point                                deadline,
+        latency_samples&                          samples) {
+
+    rpc::client_options co;
+    auto client = co_await proto.make_quic_client(co, std::move(qcfg));
+
+    auto echo = proto.make_client<sstring (sstring)>(1);
+    auto ping = proto.make_client<void ()>(3);
+
+    std::vector<future<>> futs;
+    futs.reserve(concurrency);
+    for (int i = 0; i < concurrency; ++i) {
+        if (ctype == call_type_t::ping) {
+            auto call_fn = [&]() mutable {
+                return ping(*client);
+            };
+            futs.push_back(run_latency_worker(std::move(call_fn), deadline, samples));
+        } else {
+            auto call_fn = [&, p = payload]() mutable {
+                return echo(*client, p).discard_result();
+            };
+            futs.push_back(run_latency_worker(std::move(call_fn), deadline, samples));
+        }
+    }
+
+    auto worker_results = co_await when_all(futs.begin(), futs.end());
+    for (auto& f : worker_results) {
+        try { f.get(); }
+        catch (const std::exception& e) {
+            std::cerr << "[client] worker error: " << e.what() << "\n";
+        }
+    }
+    try { co_await client->stop(); } catch (...) {}
+}
+
+// ---------------------------------------------------------------------------
+// Stats printers
+// ---------------------------------------------------------------------------
+
+static const char* call_type_name(call_type_t c) {
+    switch (c) {
+        case call_type_t::echo: return "echo";
+        case call_type_t::discard: return "discard";
+        case call_type_t::ping: return "ping";
+    }
+    return "?";
+}
+
+static void print_throughput(
+        const throughput_result& r,
+        double                   elapsed_s,
+        call_type_t              ctype,
+        int                      n_conns,
+        int                      concurrency,
+        size_t                   msg_size) {
+
+    fmt::print("\n=== Integrated RPC/QUIC Throughput Benchmark: call-type={} ===\n",
+        call_type_name(ctype));
+    fmt::print("  Connections: {}  Concurrency/conn: {}  Msg size: {} B  Elapsed: {:.2f} s\n",
+        n_conns, concurrency, msg_size, elapsed_s);
+    fmt::print("  Calls: {}  ({:.0f} calls/s)\n",
+        r.calls_done, r.calls_done / elapsed_s);
+    fmt::print("  TX: {} bytes  ({:.2f} MB/s)\n",
+        r.bytes_sent, r.bytes_sent / 1e6 / elapsed_s);
+    fmt::print("  RX: {} bytes  ({:.2f} MB/s)\n",
+        r.bytes_received, r.bytes_received / 1e6 / elapsed_s);
+    fmt::print("\n");
+    std::cout.flush();
+}
+
+static void print_latency(
+        const latency_samples& raw_samples,
+        double                 elapsed_s,
+        call_type_t            ctype,
+        int                    n_conns,
+        int                    concurrency,
+        size_t                 msg_size) {
+
+    fmt::print("\n=== Integrated RPC/QUIC Latency Benchmark: call-type={} ===\n",
+        call_type_name(ctype));
+    fmt::print("  Connections: {}  Concurrency/conn: {}  Msg size: {} B  Elapsed: {:.2f} s\n",
+        n_conns, concurrency, msg_size, elapsed_s);
+
+    if (raw_samples.empty()) {
+        fmt::print("  No samples collected.\n\n");
+        std::cout.flush();
+        return;
+    }
+
+    auto samples = raw_samples;
+    std::sort(samples.begin(), samples.end());
+    const size_t count = samples.size();
+
+    auto percentile_ms = [&](double p) -> double {
+        size_t idx = static_cast<size_t>(p / 100.0 * static_cast<double>(count));
+        if (idx >= count) { idx = count - 1; }
+        return static_cast<double>(samples[idx]) / 1000.0;
+    };
+
+    double mean_ms = static_cast<double>(
+        std::accumulate(samples.begin(), samples.end(), int64_t{0}))
+        / static_cast<double>(count) / 1000.0;
+
+    fmt::print("  Samples:  {}\n",   count);
+    fmt::print("  mean:     {:.3f} ms\n", mean_ms);
+    fmt::print("  p50:      {:.3f} ms\n", percentile_ms(50));
+    fmt::print("  p95:      {:.3f} ms\n", percentile_ms(95));
+    fmt::print("  p99:      {:.3f} ms\n", percentile_ms(99));
+    fmt::print("  p99.9:    {:.3f} ms\n", percentile_ms(99.9));
+    fmt::print("  max:      {:.3f} ms\n", static_cast<double>(samples.back()) / 1000.0);
+    fmt::print("\n");
+    std::cout.flush();
+}
+
+// ---------------------------------------------------------------------------
+// main
+// ---------------------------------------------------------------------------
+
+int main(int argc, char** argv) {
+    app_template app;
+    app.add_options()
+        ("address", bpo::value<std::string>()->default_value("::1"),
+         "Server IPv6 address")
+        ("port", bpo::value<uint16_t>()->default_value(10000),
+         "Server UDP port")
+        ("server-name", bpo::value<std::string>()->default_value("localhost"),
+         "TLS server name (SNI)")
+        ("ca", bpo::value<std::string>()->default_value("server.crt"),
+         "PEM CA/certificate file used to verify the server")
+        ("mode", bpo::value<std::string>()->default_value("throughput"),
+         "Benchmark mode: throughput or latency")
+        ("call-type", bpo::value<std::string>()->default_value("echo"),
+         "RPC call type: echo (round-trip) or ping (zero-payload, latency only). "
+         "discard/no_wait is intentionally unsupported in the integrated suite.")
+        ("connections", bpo::value<int>()->default_value(1),
+         "Number of parallel RPC clients")
+        ("concurrency", bpo::value<int>()->default_value(1),
+         "In-flight calls per client")
+        ("message-size", bpo::value<size_t>()->default_value(65536),
+         "Payload size in bytes (throughput default: 64 KiB)")
+        ("duration", bpo::value<unsigned>()->default_value(10),
+         "Benchmark duration in seconds");
+
+    return app.run(argc, argv, [&app]() -> future<int> {
+        static logger log("rpc_quic_bench");
+        std::exception_ptr error;
+
+        rpc_proto proto(serializer{});
+        proto.set_logger(&log);
+
+        try {
+            auto&& cfg       = app.configuration();
+            auto address     = cfg["address"].as<std::string>();
+            auto port        = cfg["port"].as<uint16_t>();
+            auto server_name = cfg["server-name"].as<std::string>();
+            auto ca_file     = cfg["ca"].as<std::string>();
+            auto mode        = cfg["mode"].as<std::string>();
+            auto ctype       = parse_call_type(cfg["call-type"].as<std::string>());
+            auto n_conns     = cfg["connections"].as<int>();
+            auto concurrency = cfg["concurrency"].as<int>();
+            auto msg_size    = cfg["message-size"].as<size_t>();
+            auto dur_s       = cfg["duration"].as<unsigned>();
+
+            if (mode != "throughput" && mode != "latency") {
+                throw std::runtime_error(
+                    "Unknown mode '" + mode + "': expected throughput or latency");
+            }
+            if (mode == "throughput" && ctype == call_type_t::ping) {
+                throw std::runtime_error("call-type ping is latency-only");
+            }
+            if (mode == "latency" && ctype == call_type_t::discard) {
+                throw std::runtime_error("call-type discard is throughput-only");
+            }
+            if (n_conns < 1 || concurrency < 1) {
+                throw std::runtime_error("--connections and --concurrency must be >= 1");
+            }
+            if (msg_size < 1) {
+                throw std::runtime_error("--message-size must be >= 1");
+            }
+
+            sstring payload = uninitialized_string(msg_size);
+            std::fill(payload.data(), payload.data() + msg_size, 'Q');
+
+            auto addr = parse_ipv6_address(address, port);
+
+            auto make_client_cfg = [&]() {
+                quic::experimental::quic_client_config c;
+                c.remote_address = addr;
+                c.server_name    = server_name;
+                if (!ca_file.empty()) { c.ca_file = ca_file; }
+                c.alpns = {sstring("seastar-rpc")};
+                c.session_options.max_pending_send_bytes    = 256 * 1024 * 1024;
+                c.session_options.max_pending_receive_bytes = 256 * 1024 * 1024;
+                c.session_options.transport.initial_max_stream_data_bidi_local  = 256 * 1024 * 1024;
+                c.session_options.transport.initial_max_stream_data_bidi_remote = 256 * 1024 * 1024;
+                c.session_options.transport.initial_max_data         = 16ull * 1024 * 1024 * 1024;
+                c.session_options.transport.initial_max_streams_bidi = 1u << 24;
+                return c;
+            };
+
+            const auto deadline = bm_clock::now() + std::chrono::seconds(dur_s);
+
+            fmt::print(
+                "[client] mode={} call-type={} conns={} concurrency/conn={} msg={}B dur={}s\n",
+                mode, call_type_name(ctype), n_conns, concurrency, msg_size, dur_s);
+            std::cout.flush();
+
+            if (mode == "throughput") {
+                throughput_result total;
+                const auto bench_start = bm_clock::now();
+
+                std::vector<future<>> conn_futs;
+                conn_futs.reserve(n_conns);
+                for (int c = 0; c < n_conns; ++c) {
+                    conn_futs.push_back(
+                        run_connection_throughput(
+                            proto, make_client_cfg(),
+                            concurrency, ctype, payload, deadline, total));
+                }
+                auto conn_results = co_await when_all(conn_futs.begin(), conn_futs.end());
+                for (auto& f : conn_results) {
+                    try { f.get(); }
+                    catch (const std::exception& e) {
+                        std::cerr << "[client] connection error: " << e.what() << "\n";
+                    }
+                }
+
+                // Use the "bench window" elapsed time (start → last successful
+                // call), not the wall clock until when_all() resolves. The
+                // integrated stack can hang ~60s in client->stop() on teardown
+                // for 64 KB configs; using wall clock would inflate elapsed
+                // and report a misleadingly low throughput. If no calls
+                // succeeded, fall back to wall clock (still 0/0 = NaN, but
+                // calls_done=0 makes that obvious).
+                const auto end = total.last_call_end != time_point{}
+                                     ? total.last_call_end
+                                     : bm_clock::now();
+                double elapsed = std::chrono::duration<double>(end - bench_start).count();
+                print_throughput(total, elapsed, ctype, n_conns, concurrency, msg_size);
+            } else {
+                latency_samples all_samples;
+                const auto bench_start = bm_clock::now();
+
+                std::vector<future<>> conn_futs;
+                conn_futs.reserve(n_conns);
+                for (int c = 0; c < n_conns; ++c) {
+                    conn_futs.push_back(
+                        run_connection_latency(
+                            proto, make_client_cfg(),
+                            concurrency, ctype, payload, deadline, all_samples));
+                }
+                auto conn_results = co_await when_all(conn_futs.begin(), conn_futs.end());
+                for (auto& f : conn_results) {
+                    try { f.get(); }
+                    catch (const std::exception& e) {
+                        std::cerr << "[client] connection error: " << e.what() << "\n";
+                    }
+                }
+
+                double elapsed = std::chrono::duration<double>(
+                    bm_clock::now() - bench_start).count();
+                print_latency(all_samples, elapsed, ctype, n_conns, concurrency, msg_size);
+            }
+        } catch (...) {
+            error = std::current_exception();
+        }
+
+        if (error) {
+            try {
+                std::rethrow_exception(error);
+            } catch (const std::exception& e) {
+                std::cerr << "[client] fatal: " << e.what() << "\n";
+            } catch (...) {
+                std::cerr << "[client] fatal: unknown exception\n";
+            }
+            co_return 1;
+        }
+        co_return 0;
+    });
+}

--- a/demos/benchmarks/rpc_quic_bench_server.cc
+++ b/demos/benchmarks/rpc_quic_bench_server.cc
@@ -1,0 +1,277 @@
+/*
+ * This file is open source software, licensed to you under the terms
+ * of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.  You may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Copyright (C) 2026 ScyllaDB Ltd.
+ */
+
+// Integrated RPC-on-QUIC benchmark server.
+//
+// Same shape as ../../rpc-quic-transport/src/rpc_bench_server.cc, but uses the
+// QUIC-integrated RPC API from feature/quic-rpc-integration:
+//   - a QUIC-backed rpc::server acceptor instead of an rpc_quic_adapters socket
+//   - header <seastar/rpc/rpc_quic_transport.hh>
+//
+// The integrated implementation is currently stable only for "well-behaved"
+// clients (no cancellations, no no_wait calls). To stay within that envelope
+// this benchmark only registers two verbs:
+//
+//   verb 1  echo(sstring) -> sstring   -- returns the received payload
+//   verb 3  ping() -> void              -- zero-payload round-trip
+//
+// (Verb id 2 / no_wait "discard" is intentionally not registered; the matching
+//  client also omits it.)
+
+#include <arpa/inet.h>
+
+#include <cstdint>
+#include <exception>
+#include <iostream>
+#include <optional>
+#include <stdexcept>
+#include <string>
+
+#include <fmt/core.h>
+
+#include <seastar/core/abort_source.hh>
+#include <seastar/core/app-template.hh>
+#include <seastar/core/coroutine.hh>
+#include <seastar/core/reactor.hh>
+#include <seastar/core/sleep.hh>
+#include <seastar/quic/quic_server.hh>
+#include <seastar/rpc/rpc.hh>
+#include <seastar/rpc/rpc_quic_transport.hh>
+#include <seastar/util/log.hh>
+
+#include "../../apps/lib/stop_signal.hh"
+
+using namespace seastar;
+namespace bpo = boost::program_options;
+
+// ---------------------------------------------------------------------------
+// Minimal serializer -- matches the transport-suite benchmarks
+// ---------------------------------------------------------------------------
+
+struct serializer {};
+
+template <typename T, typename Output>
+inline void write_arithmetic_type(Output& out, T v) {
+    static_assert(std::is_arithmetic_v<T>, "must be arithmetic type");
+    return out.write(reinterpret_cast<const char*>(&v), sizeof(T));
+}
+
+template <typename T, typename Input>
+inline T read_arithmetic_type(Input& in) {
+    static_assert(std::is_arithmetic_v<T>, "must be arithmetic type");
+    T v;
+    in.read(reinterpret_cast<char*>(&v), sizeof(T));
+    return v;
+}
+
+template <typename Output>
+inline void write(serializer, Output& output, int32_t v)  { return write_arithmetic_type(output, v); }
+template <typename Output>
+inline void write(serializer, Output& output, uint32_t v) { return write_arithmetic_type(output, v); }
+template <typename Output>
+inline void write(serializer, Output& output, int64_t v)  { return write_arithmetic_type(output, v); }
+template <typename Output>
+inline void write(serializer, Output& output, uint64_t v) { return write_arithmetic_type(output, v); }
+template <typename Input>
+inline int32_t  read(serializer, Input& input, rpc::type<int32_t>)  { return read_arithmetic_type<int32_t>(input); }
+template <typename Input>
+inline uint32_t read(serializer, Input& input, rpc::type<uint32_t>) { return read_arithmetic_type<uint32_t>(input); }
+template <typename Input>
+inline int64_t  read(serializer, Input& input, rpc::type<int64_t>)  { return read_arithmetic_type<int64_t>(input); }
+template <typename Input>
+inline uint64_t read(serializer, Input& input, rpc::type<uint64_t>) { return read_arithmetic_type<uint64_t>(input); }
+
+template <typename Output>
+inline void write(serializer, Output& out, const sstring& v) {
+    write_arithmetic_type(out, uint32_t(v.size()));
+    out.write(v.c_str(), v.size());
+}
+template <typename Input>
+inline sstring read(serializer, Input& in, rpc::type<sstring>) {
+    auto size = read_arithmetic_type<uint32_t>(in);
+    sstring ret = uninitialized_string(size);
+    in.read(ret.data(), size);
+    return ret;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+static socket_address parse_ipv6_address(const std::string& ip, uint16_t port) {
+    sockaddr_in6 sa{};
+    sa.sin6_family = AF_INET6;
+    sa.sin6_port = htons(port);
+    if (inet_pton(AF_INET6, ip.c_str(), &sa.sin6_addr) != 1) {
+        throw std::runtime_error("Invalid IPv6 address: " + ip);
+    }
+    return socket_address(sa);
+}
+
+struct server_stats {
+    uint64_t bytes_received = 0;
+    uint64_t bytes_echoed   = 0;
+    uint64_t calls_echo     = 0;
+    uint64_t calls_ping     = 0;
+};
+
+static server_stats g_stats;
+
+static future<> print_stats_loop(unsigned interval_s, abort_source& as) {
+    uint64_t prev_rx = 0, prev_tx = 0;
+    uint64_t prev_calls = 0;
+    try {
+        while (true) {
+            co_await sleep_abortable(std::chrono::seconds(interval_s), as);
+            uint64_t rx = g_stats.bytes_received;
+            uint64_t tx = g_stats.bytes_echoed;
+            uint64_t calls = g_stats.calls_echo + g_stats.calls_ping;
+            double rx_mb_s = static_cast<double>(rx - prev_rx) / 1e6 / interval_s;
+            double tx_mb_s = static_cast<double>(tx - prev_tx) / 1e6 / interval_s;
+            double call_rate = static_cast<double>(calls - prev_calls) / interval_s;
+            prev_rx = rx; prev_tx = tx; prev_calls = calls;
+            fmt::print(
+                "[server] calls/s={:.0f} echo={} ping={} rx={:.1f} MB/s tx={:.1f} MB/s\n",
+                call_rate,
+                g_stats.calls_echo, g_stats.calls_ping,
+                rx_mb_s, tx_mb_s);
+            std::cout.flush();
+        }
+    } catch (const sleep_aborted&) {
+        // Normal shutdown path.
+    }
+}
+
+int main(int argc, char** argv) {
+    app_template app;
+    app.add_options()
+        ("address", bpo::value<std::string>()->default_value("::1"),
+         "Server IPv6 address")
+        ("port", bpo::value<uint16_t>()->default_value(10000),
+         "Server UDP port")
+        ("crt", bpo::value<std::string>()->default_value("server.crt"),
+         "PEM certificate file")
+        ("key,k", bpo::value<std::string>()->default_value("server.key"),
+         "PEM private-key file")
+        ("stats-interval", bpo::value<unsigned>()->default_value(1),
+         "Stats printing interval in seconds (0 to disable)")
+        ("max-memory", bpo::value<uint64_t>()->default_value(256'000'000),
+         "RPC server max in-flight memory (bytes)");
+
+    return app.run(argc, argv, [&app]() -> future<int> {
+        static logger log("rpc_quic_bench");
+        std::exception_ptr error;
+        abort_source stats_as;
+        std::optional<future<>> stats_task;
+
+        rpc::protocol<serializer> myrpc(serializer{});
+        myrpc.set_logger(&log);
+
+        // verb 1: echo payload back
+        myrpc.register_handler(1, [](sstring payload) {
+            g_stats.bytes_received += payload.size();
+            g_stats.bytes_echoed   += payload.size();
+            ++g_stats.calls_echo;
+            return payload;
+        });
+        // verb 2: discard payload, fire-and-forget (no_wait)
+        myrpc.register_handler(2, [](sstring payload) {
+            g_stats.bytes_received += payload.size();
+            return rpc::no_wait;
+        });
+        // verb 3: ping -> empty reply
+        myrpc.register_handler(3, []() {
+            ++g_stats.calls_ping;
+            return make_ready_future<>();
+        });
+
+        std::unique_ptr<rpc::protocol<serializer>::server> server;
+
+        try {
+            auto&& cfg = app.configuration();
+            auto address    = cfg["address"].as<std::string>();
+            auto port       = cfg["port"].as<uint16_t>();
+            auto crt        = cfg["crt"].as<std::string>();
+            auto key        = cfg["key"].as<std::string>();
+            auto stats_intv = cfg["stats-interval"].as<unsigned>();
+            auto max_mem    = cfg["max-memory"].as<uint64_t>();
+
+            auto listen_addr = parse_ipv6_address(address, port);
+
+            quic::experimental::quic_server_config server_cfg;
+            server_cfg.listen_address = listen_addr;
+            server_cfg.crt_file = crt;
+            server_cfg.key_file = key;
+            server_cfg.alpns = {sstring("seastar-rpc")};
+            server_cfg.session_options.max_pending_send_bytes    = 256 * 1024 * 1024;
+            server_cfg.session_options.max_pending_receive_bytes = 256 * 1024 * 1024;
+            server_cfg.session_options.transport.initial_max_stream_data_bidi_local  = 256 * 1024 * 1024;
+            server_cfg.session_options.transport.initial_max_stream_data_bidi_remote = 256 * 1024 * 1024;
+            server_cfg.session_options.transport.initial_max_data        = 16ull * 1024 * 1024 * 1024;
+            server_cfg.session_options.transport.initial_max_streams_bidi = 1u << 24;
+
+            rpc::resource_limits limits;
+            limits.bloat_factor       = 1;
+            limits.basic_request_size = 0;
+            limits.max_memory         = max_mem;
+
+            rpc::server_options so;
+
+            server = std::make_unique<rpc::protocol<serializer>::server>(
+                    myrpc, so, std::move(server_cfg), limits);
+
+            if (stats_intv > 0) {
+                stats_task.emplace(print_stats_loop(stats_intv, stats_as));
+            }
+
+            fmt::print("[server] RPC bench server listening on [{}]:{}\n", address, port);
+            fmt::print("[server] Ctrl-C to stop.\n");
+            std::cout.flush();
+
+            seastar_apps_lib::stop_signal stop_signal;
+            co_await stop_signal.wait();
+            fmt::print("[server] shutting down...\n");
+            std::cout.flush();
+        } catch (...) {
+            error = std::current_exception();
+        }
+
+        stats_as.request_abort();
+        if (stats_task) {
+            try { co_await std::move(*stats_task); } catch (...) {}
+        }
+        if (server) {
+            try { co_await server->stop(); } catch (...) {}
+        }
+
+        if (error) {
+            try {
+                std::rethrow_exception(error);
+            } catch (const std::exception& e) {
+                std::cerr << "[server] fatal: " << e.what() << "\n";
+            } catch (...) {
+                std::cerr << "[server] fatal: unknown exception\n";
+            }
+            co_return 1;
+        }
+        co_return 0;
+    });
+}

--- a/demos/rpc_quic_demo.cc
+++ b/demos/rpc_quic_demo.cc
@@ -1,0 +1,355 @@
+/*
+ * This file is open source software, licensed to you under the terms
+ * of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.  You may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Copyright (C) 2026 ScyllaDB Ltd.
+ *
+ * QUIC transport variant of rpc_demo.cc — identical RPC logic,
+ * only the transport creation differs (TCP → QUIC, IPv4 → IPv6).
+ */
+#include <arpa/inet.h>
+#include <cmath>
+#include <iostream>
+#include <ranges>
+#include <vector>
+#include <seastar/core/reactor.hh>
+#include <seastar/core/app-template.hh>
+#include <seastar/rpc/rpc.hh>
+#include <seastar/core/sleep.hh>
+#include <seastar/quic/quic_server.hh>
+#include <seastar/rpc/lz4_compressor.hh>
+#include <seastar/rpc/rpc_quic_transport.hh>
+#include <seastar/util/log.hh>
+#include <seastar/core/loop.hh>
+
+#include "../apps/lib/stop_signal.hh"
+
+using namespace seastar;
+
+struct serializer {
+};
+
+template <typename T, typename Output>
+inline
+void write_arithmetic_type(Output& out, T v) {
+    static_assert(std::is_arithmetic_v<T>, "must be arithmetic type");
+    return out.write(reinterpret_cast<const char*>(&v), sizeof(T));
+}
+
+template <typename T, typename Input>
+inline
+T read_arithmetic_type(Input& in) {
+    static_assert(std::is_arithmetic_v<T>, "must be arithmetic type");
+    T v;
+    in.read(reinterpret_cast<char*>(&v), sizeof(T));
+    return v;
+}
+
+template <typename Output>
+inline void write(serializer, Output& output, int32_t v) { return write_arithmetic_type(output, v); }
+template <typename Output>
+inline void write(serializer, Output& output, uint32_t v) { return write_arithmetic_type(output, v); }
+template <typename Output>
+inline void write(serializer, Output& output, int64_t v) { return write_arithmetic_type(output, v); }
+template <typename Output>
+inline void write(serializer, Output& output, uint64_t v) { return write_arithmetic_type(output, v); }
+template <typename Output>
+inline void write(serializer, Output& output, double v) { return write_arithmetic_type(output, v); }
+template <typename Input>
+inline int32_t read(serializer, Input& input, rpc::type<int32_t>) { return read_arithmetic_type<int32_t>(input); }
+template <typename Input>
+inline uint32_t read(serializer, Input& input, rpc::type<uint32_t>) { return read_arithmetic_type<uint32_t>(input); }
+template <typename Input>
+inline uint64_t read(serializer, Input& input, rpc::type<uint64_t>) { return read_arithmetic_type<uint64_t>(input); }
+template <typename Input>
+inline uint64_t read(serializer, Input& input, rpc::type<int64_t>) { return read_arithmetic_type<int64_t>(input); }
+template <typename Input>
+inline double read(serializer, Input& input, rpc::type<double>) { return read_arithmetic_type<double>(input); }
+
+template <typename Output>
+inline void write(serializer, Output& out, const sstring& v) {
+    write_arithmetic_type(out, uint32_t(v.size()));
+    out.write(v.c_str(), v.size());
+}
+
+template <typename Input>
+inline sstring read(serializer, Input& in, rpc::type<sstring>) {
+    auto size = read_arithmetic_type<uint32_t>(in);
+    sstring ret = uninitialized_string(size);
+    in.read(ret.data(), size);
+    return ret;
+}
+
+namespace bpo = boost::program_options;
+using namespace std::chrono_literals;
+
+class mycomp : public rpc::compressor::factory {
+    const sstring _name = "LZ4";
+public:
+    virtual const sstring& supported() const override {
+        fmt::print("supported called\n");
+        return _name;
+    }
+    virtual std::unique_ptr<rpc::compressor> negotiate(sstring feature, bool is_server) const override {
+        fmt::print("negotiate called with {}\n", feature);
+        return feature == _name ? std::make_unique<rpc::lz4_compressor>() : nullptr;
+    }
+};
+
+// IPv6 address helper
+static socket_address make_ipv6_address(const std::string& ip, uint16_t port) {
+    sockaddr_in6 sa{};
+    sa.sin6_family = AF_INET6;
+    sa.sin6_port = htons(port);
+    if (inet_pton(AF_INET6, ip.c_str(), &sa.sin6_addr) != 1) {
+        throw std::runtime_error("Invalid IPv6 address: " + ip);
+    }
+    return socket_address(sa);
+}
+
+int main(int ac, char** av) {
+    app_template app;
+    app.add_options()
+                    ("port", bpo::value<uint16_t>()->default_value(10000), "RPC server port")
+                    ("server", bpo::value<std::string>(), "Server address")
+                    ("compress", bpo::value<bool>()->default_value(false), "Compress RPC traffic")
+                    // QUIC options
+                    ("address", bpo::value<std::string>()->default_value("::1"), "IPv6 listen/connect address")
+                    ("crt", bpo::value<std::string>()->default_value("server.crt"), "PEM certificate file")
+                    ("key,k", bpo::value<std::string>()->default_value("server.key"), "PEM key file")
+                    ("ca", bpo::value<std::string>()->default_value("server.crt"), "PEM CA file for client");
+    std::cout << "starting ";
+    rpc::protocol<serializer> myrpc(serializer{});
+    static std::unique_ptr<rpc::protocol<serializer>::server> server;
+    static std::unique_ptr<rpc::protocol<serializer>::client> client;
+    static double x = 30.0;
+
+    static logger log("quic_rpc_demo");
+    myrpc.set_logger(&log);
+
+    return app.run(ac, av, [&] () -> future<> {
+        auto&& config = app.configuration();
+        uint16_t port = config["port"].as<uint16_t>();
+        bool compress = config["compress"].as<bool>();
+        auto address = config["address"].as<std::string>();
+        auto crt = config["crt"].as<std::string>();
+        auto key = config["key"].as<std::string>();
+        auto ca = config["ca"].as<std::string>();
+        static mycomp mc;
+        auto test1 = myrpc.register_handler(1, [x = 0](int i) mutable { fmt::print("test1 count {:d} got {:d}\n", ++x, i); });
+        auto test2 = myrpc.register_handler(2, [](int a, int b){ fmt::print("test2 got {:d} {:d}\n", a, b); return make_ready_future<int>(a+b); });
+        auto test3 = myrpc.register_handler(3, [](double x){ fmt::print("test3 got {:f}\n", x); return std::make_unique<double>(sin(x)); });
+        auto test4 = myrpc.register_handler(4, [](){ fmt::print("test4 throw!\n"); throw std::runtime_error("exception!"); });
+        auto test5 = myrpc.register_handler(5, [](){ fmt::print("test5 no wait\n"); return rpc::no_wait; });
+        auto test6 = myrpc.register_handler(6, [](const rpc::client_info& info, int x){ fmt::print("test6 client {}, {:d}\n", info.addr, x); });
+        auto test8 = myrpc.register_handler(8, [](){ fmt::print("test8 sleep for 2 sec\n"); return sleep(2s); });
+        auto test13 = myrpc.register_handler(13, [](){ fmt::print("test13 sleep for 1 msec\n"); return sleep(1ms); });
+        (void)myrpc.register_handler(14, [](sstring payload){ fmt::print("message too large handler should not run"); });
+
+        if (config.count("server")) {
+            std::cout << "client" << std::endl;
+            auto test7 = myrpc.make_client<long (long a, long b)>(7);
+            auto test9 = myrpc.make_client<long (long a, long b)>(9); // do not send optional
+            auto test9_1 = myrpc.make_client<long (long a, long b, int c)>(9); // send optional
+            auto test9_2 = myrpc.make_client<long (long a, long b, int c, long d)>(9); // send more data than handler expects
+            auto test10 = myrpc.make_client<long ()>(10); // receive less then replied
+            auto test10_1 = myrpc.make_client<future<rpc::tuple<long, int>> ()>(10); // receive all
+            auto test11 = myrpc.make_client<future<rpc::tuple<long, rpc::optional<int>>> ()>(11); // receive more then replied
+            auto test_nohandler = myrpc.make_client<void ()>(100000000); // non existing verb
+            auto test_nohandler_nowait = myrpc.make_client<rpc::no_wait_type ()>(100000000); // non existing verb, no_wait call
+            rpc::client_options co;
+            if (compress) {
+                co.compressor_factory = &mc;
+            }
+
+            // QUIC transport
+            auto addr = make_ipv6_address(config["server"].as<std::string>(), port);
+            quic::experimental::quic_client_config client_cfg;
+            client_cfg.remote_address = addr;
+            client_cfg.server_name = "localhost";
+            client_cfg.ca_file = ca;
+            client_cfg.alpns = {sstring("seastar-rpc")};
+            client_cfg.session_options.transport.initial_max_stream_data_bidi_local = 4 * 1024 * 1024;
+            client_cfg.session_options.transport.initial_max_stream_data_bidi_remote = 4 * 1024 * 1024;
+            client_cfg.session_options.transport.initial_max_data = 64 * 1024 * 1024;
+            client_cfg.session_options.transport.initial_max_streams_bidi = 512;
+            client = co_await myrpc.make_quic_client(co, std::move(client_cfg));
+
+            std::vector<future<>> pending;
+            pending.reserve(1400);
+            auto background = [&pending] (auto fut) {
+                pending.push_back(std::move(fut).then_wrapped([] (auto f) {
+                    try {
+                        f.get();
+                    } catch (const rpc::closed_error&) {
+                    } catch (...) {
+                    }
+                }));
+            };
+
+            pending.push_back(test8(*client, 1500ms).then_wrapped([](future<> f) {
+                try {
+                    f.get();
+                    printf("test8 should not get here!\n");
+                } catch (rpc::timeout_error&) {
+                    printf("test8 timeout!\n");
+                } catch (rpc::closed_error&) {
+                    fmt::print("test8 connection is closed\n");
+                }
+            }));
+            for (auto i = 0; i < 10; i++) {
+                fmt::print("iteration={:d}\n", i);
+                background(test1(*client, 5).then([] (){ fmt::print("test1 ended\n");}));
+                background(test2(*client, 1, 2).then([] (int r) { fmt::print("test2 got {:d}\n", r); }));
+                background(test3(*client, x).then([](double x) { fmt::print("sin={:f}\n", x); }));
+                background(test4(*client).then_wrapped([](future<> f) {
+                    try {
+                        f.get();
+                        fmt::print("test4 should not succeed\n");
+                    } catch (std::runtime_error& x){
+                        fmt::print("test4 {}\n", x.what());
+                    }
+                }));
+                background(test5(*client).then([] { fmt::print("test5 no wait ended\n"); }));
+                background(test6(*client, 1).then([] { fmt::print("test6 ended\n"); }));
+                background(test7(*client, 5, 6).then([] (long r) { fmt::print("test7 got {:d}\n", r); }));
+                background(test9(*client, 1, 2).then([] (long r) { fmt::print("test9 got {:d}\n", r); }));
+                background(test9_1(*client, 1, 2, 3).then([] (long r) { fmt::print("test9.1 got {:d}\n", r); }));
+                background(test9_2(*client, 1, 2, 3, 4).then([] (long r) { fmt::print("test9.2 got {:d}\n", r); }));
+                background(test10(*client).then([] (long r) { fmt::print("test10 got {:d}\n", r); }));
+                background(test10_1(*client).then([] (rpc::tuple<long, int> r) { fmt::print("test10_1 got {:d} and {:d}\n", std::get<0>(r), std::get<1>(r)); }));
+                background(test11(*client).then([] (rpc::tuple<long, rpc::optional<int> > r) { fmt::print("test11 got {:d} and {:d}\n", std::get<0>(r), bool(std::get<1>(r))); }));
+                background(test_nohandler(*client).then_wrapped([](future<> f) {
+                    try {
+                        f.get();
+                        fmt::print("test_nohandler should not succeed\n");
+                    } catch (rpc::unknown_verb_error& x){
+                        fmt::print("test_nohandle no such verb\n");
+                    } catch (...) {
+                        fmt::print("incorrect exception!\n");
+                    }
+                }));
+                background(test_nohandler_nowait(*client));
+                auto c1 = make_lw_shared<rpc::cancellable>();
+                background(test13(*client, *c1).then_wrapped([](future<> f) {
+                    try {
+                        f.get();
+                        fmt::print("test13 should not succeed\n");
+                    } catch(rpc::canceled_error&) {
+                        fmt::print("test13 canceled\n");
+                    } catch(...) {
+                        fmt::print("test13 wrong exception\n");
+                    }
+                }));
+                c1->cancel();
+                auto c2 = make_lw_shared<rpc::cancellable>();
+                background(test13(*client, *c2).then_wrapped([](future<> f) {
+                    try {
+                        f.get();
+                        fmt::print("test13 should not succeed\n");
+                    } catch(rpc::canceled_error&) {
+                        fmt::print("test13 canceled\n");
+                    } catch(...) {
+                        fmt::print("test13 wrong exception\n");
+                    }
+                }));
+                (void)sleep(500us).then([c2] { c2->cancel(); });
+                // (void)test_message_to_big(*client, uninitialized_string(10'000'001)).then_wrapped([](future<> f) {
+                //     try {
+                //         f.get();
+                //         fmt::print("message too large handler should not run\n");
+                //     } catch(std::runtime_error& err) {
+                //         fmt::print("test message to big get error {}\n", err.what());
+                //     } catch(...) {
+                //         fmt::print("test message to big wrong exception\n");
+                //     }
+                // });
+            }
+            co_await when_all(pending.begin(), pending.end()).discard_result();
+            co_await client->stop();
+        } else {
+            std::cout << "server on port " << port << std::endl;
+            myrpc.register_handler(7, [](long a, long b) mutable {
+                auto p = make_lw_shared<promise<>>();
+                auto t = make_lw_shared<timer<>>();
+                fmt::print("test7 got {:d} {:d}\n", a, b);
+                auto f = p->get_future().then([a, b, t] {
+                    fmt::print("test7 calc res\n");
+                    return a - b;
+                });
+                t->set_callback([p = std::move(p)] () mutable { p->set_value(); });
+                t->arm(1s);
+                return f;
+            });
+            myrpc.register_handler(9, [] (long a, long b, rpc::optional<int> c) {
+                long r = 2;
+                fmt::print("test9 got {:d} {:d} ", a, b);
+                if (c) {
+                    fmt::print("{:d}", c.value());
+                    r++;
+                }
+                fmt::print("\n");
+                return r;
+            });
+            myrpc.register_handler(10, [] {
+                fmt::print("test 10\n");
+                return make_ready_future<rpc::tuple<long, int>>(rpc::tuple<long, int>(1, 2));
+            });
+            myrpc.register_handler(11, [] {
+                fmt::print("test 11\n");
+                return 1ul;
+            });
+            myrpc.register_handler(12, [] (int sleep_ms, sstring payload) {
+                return sleep(std::chrono::milliseconds(sleep_ms)).then([] {
+                    return make_ready_future<>();
+                });
+            });
+
+            // QUIC transport
+            auto addr = make_ipv6_address(address, port);
+            quic::experimental::quic_server_config server_cfg;
+            server_cfg.listen_address = addr;
+            server_cfg.crt_file = crt;
+            server_cfg.key_file = key;
+            server_cfg.alpns = {sstring("seastar-rpc")};
+            server_cfg.session_options.transport.initial_max_stream_data_bidi_local = 4 * 1024 * 1024;
+            server_cfg.session_options.transport.initial_max_stream_data_bidi_remote = 4 * 1024 * 1024;
+            server_cfg.session_options.transport.initial_max_data = 64 * 1024 * 1024;
+            server_cfg.session_options.transport.initial_max_streams_bidi = 512;
+
+            rpc::resource_limits limits;
+            limits.bloat_factor = 1;
+            limits.basic_request_size = 0;
+            limits.max_memory = 10'000'000;
+            rpc::server_options so;
+            if (compress) {
+                so.compressor_factory = &mc;
+            }
+            server = std::make_unique<rpc::protocol<serializer>::server>(
+                    myrpc,
+                    so,
+                    std::move(server_cfg),
+                    limits);
+
+            seastar_apps_lib::stop_signal stop_signal;
+            co_await stop_signal.wait();
+            co_await server->stop();
+        }
+        co_return;
+    });
+
+}

--- a/include/seastar/rpc/rpc.hh
+++ b/include/seastar/rpc/rpc.hh
@@ -44,8 +44,17 @@
 #include <seastar/core/semaphore.hh>
 #include <seastar/util/backtrace.hh>
 #include <seastar/util/log.hh>
+#include <seastar/util/noncopyable_function.hh>
 
 namespace bi = boost::intrusive;
+
+namespace seastar::quic::experimental {
+class connection;
+class quic_server;
+struct quic_client_config;
+struct quic_server_config;
+class stream;
+}
 
 namespace seastar {
 
@@ -236,22 +245,97 @@ class sink_impl;
 
 template<typename Serializer, typename... In>
 class source_impl;
+
+class send_cancellation_state;
+
+struct reply_handle {
+    using sender = noncopyable_function<future<> (snd_buf&&, std::optional<rpc_clock_type::time_point>)>;
+    using closer = noncopyable_function<future<> ()>;
+
+    sender send;
+    closer close;
+
+    reply_handle() = default;
+    explicit reply_handle(sender s, closer c = {}) noexcept
+        : send(std::move(s))
+        , close(std::move(c)) {
+    }
+
+    explicit operator bool() const noexcept {
+        return static_cast<bool>(send) || static_cast<bool>(close);
+    }
+};
+
+struct incoming_response {
+    int64_t msg_id = 0;
+    std::optional<uint32_t> handler_duration;
+    std::optional<rcv_buf> data;
+};
+
+struct incoming_request {
+    std::optional<uint64_t> expire;
+    uint64_t type = 0;
+    int64_t msg_id = 0;
+    std::optional<rcv_buf> data;
+    reply_handle reply;
+};
+}
+
+class connected_socket_transport;
+
+namespace experimental {
+class quic_client_transport;
+class quic_server_transport;
 }
 
 class connection {
-protected:
-    struct socket_and_buffers {
-        connected_socket fd;
-        input_stream<char> read_buf;
-        output_stream<char> write_buf;
-        socket_and_buffers(connected_socket cs) noexcept
-                : fd(std::move(cs))
-                , read_buf(fd.input())
-                , write_buf(fd.output())
-        {}
+public:
+    class transport {
+    public:
+        class stream {
+        public:
+            virtual ~stream() = default;
+            virtual input_stream<char>& input() = 0;
+            virtual output_stream<char>& output() = 0;
+            virtual future<> close_output() = 0;
+            virtual future<> stop_input() = 0;
+            virtual future<> abort() = 0;
+            virtual bool is_closed_exception(std::exception_ptr) const noexcept {
+                return false;
+            }
+            virtual future<> drain_input() {
+                return make_ready_future<>();
+            }
+        };
+
+        virtual ~transport() = default;
+
+        virtual input_stream<char>& input() = 0;
+        virtual output_stream<char>& output() = 0;
+        virtual void shutdown_input() = 0;
+        virtual void shutdown_output() = 0;
+        virtual future<> stop() {
+            shutdown_input();
+            shutdown_output();
+            return make_ready_future<>();
+        }
+        virtual bool supports_multiplexed_requests() const {
+            return false;
+        }
+        virtual bool is_closed_exception(std::exception_ptr) const noexcept {
+            return false;
+        }
+        virtual future<std::unique_ptr<stream>> open_request_stream() {
+            return make_exception_future<std::unique_ptr<stream>>(std::runtime_error("transport does not support opening RPC request streams"));
+        }
+        virtual future<std::unique_ptr<stream>> accept_request_stream() {
+            return make_exception_future<std::unique_ptr<stream>>(std::runtime_error("transport does not support accepting RPC request streams"));
+        }
     };
+
+protected:
     bool _error = false;
-    std::optional<socket_and_buffers> _connected;
+    std::unique_ptr<transport> _transport;
     std::optional<shared_promise<>> _negotiated = shared_promise<>();
     promise<> _stopped;
     stats _stats;
@@ -308,6 +392,30 @@ protected:
 
     void set_negotiated() noexcept;
 
+    bool connected() const noexcept {
+        return static_cast<bool>(_transport);
+    }
+
+    input_stream<char>& transport_input() {
+        return _transport->input();
+    }
+
+    output_stream<char>& transport_output() {
+        return _transport->output();
+    }
+
+    void shutdown_transport_input() {
+        if (_transport) {
+            _transport->shutdown_input();
+        }
+    }
+
+    void shutdown_transport_output() {
+        if (_transport) {
+            _transport->shutdown_output();
+        }
+    }
+
     bool is_stream() const noexcept {
         return _is_stream;
     }
@@ -325,6 +433,11 @@ protected:
     future<> stream_process_incoming(rcv_buf&&);
     future<> handle_stream_frame();
     future<> send_negotiation_frame(feature_map features);
+    void set_transport(std::unique_ptr<transport> t);
+    internal::reply_handle make_reply_handle();
+    virtual future<internal::incoming_request> receive_request_frame(input_stream<char>& in);
+
+    friend class connected_socket_transport;
 
 public:
     connection(connected_socket&& fd, const logger& l, void* s, connection_id id = invalid_connection_id) : connection(l, s, id) {
@@ -507,6 +620,7 @@ class client : public rpc::connection, public weakly_referencable<client> {
         virtual void operator()(client&, id_type, rcv_buf data) = 0;
         virtual void timeout() {}
         virtual void cancel() {}
+        virtual void closed() {}
         virtual ~reply_handler_base() {
             if (pcancel) {
                 pcancel->cancel_wait = std::function<void()>();
@@ -535,6 +649,9 @@ class client : public rpc::connection, public weakly_referencable<client> {
 
     void enqueue_zero_frame();
     future<> loop(client_options ops, const socket_address& addr, const socket_address& local);
+    feature_map make_client_features() const;
+    future<> process_client_connection();
+    future<> loop_with_transport();
 public:
     template<typename Reply, typename Func>
     struct reply_handler final : reply_handler_base {
@@ -552,10 +669,21 @@ public:
             reply.done = true;
             reply.p.set_exception(canceled_error());
         }
+        virtual void closed() override {
+            reply.done = true;
+            reply.p.set_exception(closed_error());
+        }
         virtual ~reply_handler() {}
     };
 private:
+    struct multiplexed_request_state {
+        std::unique_ptr<transport::stream> stream;
+        bool cancelled = false;
+        bool request_sent = false;
+    };
+
     std::unordered_map<id_type, std::unique_ptr<reply_handler_base>> _outstanding;
+    std::unordered_map<id_type, lw_shared_ptr<multiplexed_request_state>> _active_multiplexed_requests;
     socket_address _server_addr, _local_addr;
     client_options _options;
     weak_ptr<client> _parent; // for stream clients
@@ -571,6 +699,19 @@ private:
     // - message payload
     future<std::tuple<int64_t, std::optional<uint32_t>, std::optional<rcv_buf>>>
     read_response_frame_compressed(input_stream<char>& in);
+    future<internal::incoming_response> receive_response_frame(input_stream<char>& in);
+    future<internal::incoming_response> receive_response();
+    void handle_response(internal::incoming_response response);
+    bool can_send_request(id_type id, bool expect_response) const;
+    void handle_multiplexed_response(id_type msg_id, internal::incoming_response response);
+    future<> send_multiplexed_request(int64_t msg_id, snd_buf buf, std::optional<rpc_clock_type::time_point> timeout, cancellable* cancel, bool expect_response);
+    future<> do_send_multiplexed_request(int64_t msg_id, snd_buf buf, std::optional<rpc_clock_type::time_point> timeout, lw_shared_ptr<internal::send_cancellation_state> cancel_state, bool expect_response, lw_shared_ptr<multiplexed_request_state> request_state);
+    bool close_outstanding_request(id_type id);
+    lw_shared_ptr<multiplexed_request_state> register_multiplexed_request(id_type id);
+    void cleanup_multiplexed_request(id_type id, lw_shared_ptr<multiplexed_request_state> request_state);
+    void abort_multiplexed_request(id_type id) noexcept;
+    void abort_all_multiplexed_requests() noexcept;
+    gate _response_gate;
 public:
     /**
      * Create client object which will attempt to connect to the remote address.
@@ -595,6 +736,7 @@ public:
      */
     client(const logger& l, void* s, socket socket, const socket_address& addr, const socket_address& local = {});
     client(const logger& l, void* s, client_options options, socket socket, const socket_address& addr, const socket_address& local = {});
+    client(const logger& l, void* s, client_options options, std::unique_ptr<transport> transport, const socket_address& addr, const socket_address& local = {});
 
     stats get_stats() const;
     size_t incoming_queue_length() const noexcept {
@@ -651,7 +793,7 @@ public:
         return make_stream_sink<Serializer, Out...>(make_socket());
     }
 
-    future<> request(uint64_t type, int64_t id, snd_buf buf, std::optional<rpc_clock_type::time_point> timeout = {}, cancellable* cancel = nullptr);
+    future<> request(uint64_t type, int64_t id, snd_buf buf, std::optional<rpc_clock_type::time_point> timeout = {}, cancellable* cancel = nullptr, bool expect_response = true);
 };
 
 class protocol_base;
@@ -661,6 +803,18 @@ private:
     static thread_local std::unordered_map<streaming_domain_type, server*> _servers;
 
 public:
+    struct accepted_connection {
+        socket_address remote_address;
+        std::unique_ptr<rpc::connection::transport> transport;
+    };
+
+    class acceptor {
+    public:
+        virtual ~acceptor() = default;
+        virtual future<accepted_connection> accept() = 0;
+        virtual future<> stop() = 0;
+    };
+
     class connection : public rpc::connection, public enable_shared_from_this<connection> {
         client_info _info;
         connection_id _parent_id = invalid_connection_id;
@@ -669,11 +823,19 @@ public:
         future<> negotiate_protocol();
         future<std::tuple<std::optional<uint64_t>, uint64_t, int64_t, std::optional<rcv_buf>>>
         read_request_frame_compressed(input_stream<char>& in);
+        future<internal::incoming_request> receive_request_frame(input_stream<char>& in) override;
+        future<internal::incoming_request> receive_quic_request_frame(input_stream<char>& in);
+        future<internal::incoming_request> receive_multiplexed_request();
+        future<internal::incoming_request> receive_request();
+        future<> process_request(internal::incoming_request request);
         future<feature_map> negotiate(feature_map requested);
-        future<> send_unknown_verb_reply(std::optional<rpc_clock_type::time_point> timeout, int64_t msg_id, uint64_t type);
+        future<> send_unknown_verb_reply(internal::reply_handle reply, std::optional<rpc_clock_type::time_point> timeout, int64_t msg_id, uint64_t type);
+        gate _request_gate;
     public:
         connection(server& s, connected_socket&& fd, socket_address&& addr, const logger& l, void* seralizer, connection_id id);
+        connection(server& s, std::unique_ptr<transport> transport, socket_address&& addr, const logger& l, void* serializer, connection_id id);
         future<> process();
+        future<> respond(internal::reply_handle reply, int64_t msg_id, snd_buf&& data, std::optional<rpc_clock_type::time_point> timeout, std::optional<rpc_clock_type::duration> handler_duration);
         future<> respond(int64_t msg_id, snd_buf&& data, std::optional<rpc_clock_type::time_point> timeout, std::optional<rpc_clock_type::duration> handler_duration);
         client_info& info() { return _info; }
         const client_info& info() const { return _info; }
@@ -710,22 +872,25 @@ public:
     };
 private:
     protocol_base& _proto;
-    server_socket _ss;
+    std::unique_ptr<acceptor> _acceptor;
     resource_limits _limits;
     rpc_semaphore _resources_available;
     std::unordered_map<connection_id, shared_ptr<connection>> _conns;
-    promise<> _ss_stopped;
+    promise<> _accept_stopped;
     gate _reply_gate;
     server_options _options;
     bool _shutdown = false;
     uint64_t _next_client_id = 1;
+
+    void accept();
 
 public:
     server(protocol_base* proto, const socket_address& addr, resource_limits memory_limit = resource_limits());
     server(protocol_base* proto, server_options opts, const socket_address& addr, resource_limits memory_limit = resource_limits());
     server(protocol_base* proto, server_socket, resource_limits memory_limit = resource_limits(), server_options opts = server_options{});
     server(protocol_base* proto, server_options opts, server_socket, resource_limits memory_limit = resource_limits());
-    void accept();
+    server(protocol_base* proto, std::unique_ptr<acceptor>, resource_limits memory_limit = resource_limits(), server_options opts = server_options{});
+    server(protocol_base* proto, server_options opts, std::unique_ptr<acceptor>, resource_limits memory_limit = resource_limits());
     /**
      * Stops the server.
      *
@@ -767,7 +932,7 @@ public:
 };
 
 using rpc_handler_func = std::function<future<> (shared_ptr<server::connection>, std::optional<rpc_clock_type::time_point> timeout, int64_t msgid,
-                                                 rcv_buf data, gate::holder guard)>;
+                                                 rcv_buf data, internal::reply_handle reply, gate::holder guard)>;
 
 struct rpc_handler {
     scheduling_group sg;
@@ -779,6 +944,7 @@ class protocol_base {
 public:
     virtual ~protocol_base() {};
     virtual shared_ptr<server::connection> make_server_connection(rpc::server& server, connected_socket fd, socket_address addr, connection_id id) = 0;
+    virtual shared_ptr<server::connection> make_server_connection(rpc::server& server, std::unique_ptr<connection::transport> transport, socket_address addr, connection_id id) = 0;
 protected:
     friend class server;
 
@@ -895,6 +1061,12 @@ public:
             rpc::server(&proto, std::move(socket), memory_limit) {}
         server(protocol& proto, server_options opts, server_socket socket, resource_limits memory_limit = resource_limits()) :
             rpc::server(&proto, opts, std::move(socket), memory_limit) {}
+        server(protocol& proto, std::unique_ptr<rpc::server::acceptor> acceptor, resource_limits memory_limit = resource_limits(), server_options opts = server_options{}) :
+            rpc::server(&proto, std::move(acceptor), memory_limit, opts) {}
+        server(protocol& proto, server_options opts, std::unique_ptr<rpc::server::acceptor> acceptor, resource_limits memory_limit = resource_limits()) :
+            rpc::server(&proto, opts, std::move(acceptor), memory_limit) {}
+        server(protocol& proto, ::seastar::quic::experimental::quic_server_config config, resource_limits memory_limit = resource_limits());
+        server(protocol& proto, server_options opts, ::seastar::quic::experimental::quic_server_config config, resource_limits memory_limit = resource_limits());
     };
     /// Represents a client side connection.
     class client : public rpc::client {
@@ -922,6 +1094,8 @@ public:
             rpc::client(p.get_logger(), &p._serializer, std::move(socket), addr, local) {}
         client(protocol& p, client_options options, socket socket, const socket_address& addr, const socket_address& local = {}) :
             rpc::client(p.get_logger(), &p._serializer, options, std::move(socket), addr, local) {}
+        client(protocol& p, client_options options, std::unique_ptr<rpc::connection::transport> transport, const socket_address& addr, const socket_address& local = {}) :
+            rpc::client(p.get_logger(), &p._serializer, options, std::move(transport), addr, local) {}
     };
 
     friend server;
@@ -944,6 +1118,9 @@ public:
     ///     signature: `future<Ret>(protocol::client&, Args...)`.
     template<typename Func>
     auto make_client(MsgType t);
+
+    future<std::unique_ptr<client>> make_quic_client(::seastar::quic::experimental::quic_client_config config);
+    future<std::unique_ptr<client>> make_quic_client(client_options options, ::seastar::quic::experimental::quic_client_config config);
 
     /// Register a handler to be called when this verb is invoked.
     ///
@@ -1004,6 +1181,10 @@ public:
 
     shared_ptr<rpc::server::connection> make_server_connection(rpc::server& server, connected_socket fd, socket_address addr, connection_id id) override {
         return make_shared<rpc::server::connection>(server, std::move(fd), std::move(addr), _logger, &_serializer, id);
+    }
+
+    shared_ptr<rpc::server::connection> make_server_connection(rpc::server& server, std::unique_ptr<connection::transport> transport, socket_address addr, connection_id id) override {
+        return seastar::make_shared<rpc::server::connection>(server, std::move(transport), std::move(addr), _logger, &_serializer, id);
     }
 
     bool has_handler(MsgType msg_id);

--- a/include/seastar/rpc/rpc_impl.hh
+++ b/include/seastar/rpc/rpc_impl.hh
@@ -575,7 +575,10 @@ auto send_helper(MsgType xt, signature<Ret (InArgs...)> xsig) {
 
             // prepare reply handler, if return type is now_wait_type this does nothing, since no reply will be sent
             using wait = wait_signature_t<Ret>;
-            return when_all(dst.request(uint64_t(t), msg_id, std::move(data), timeout, cancel), wait_for_reply<Serializer>(wait(), timeout, start, cancel, dst, msg_id, sig)).then([] (auto r) {
+            constexpr bool expect_response = !std::is_same_v<wait, no_wait_type>;
+            auto reply_f = wait_for_reply<Serializer>(wait(), timeout, start, cancel, dst, msg_id, sig);
+            auto request_f = dst.request(uint64_t(t), msg_id, std::move(data), timeout, cancel, expect_response);
+            return when_all(std::move(request_f), std::move(reply_f)).then([] (auto r) {
                     std::get<0>(r).ignore_ready_future();
                     return std::move(std::get<1>(r)); // return future of wait_for_reply
             });
@@ -607,8 +610,8 @@ auto send_helper(MsgType xt, signature<Ret (InArgs...)> xsig) {
 static constexpr size_t response_frame_headroom = 16;
 
 template<typename Serializer, typename RetTypes>
-inline future<> reply(wait_type, future<RetTypes>&& ret, uint64_t verb, int64_t msg_id, shared_ptr<server::connection> client,
-        std::optional<rpc_clock_type::time_point> timeout, std::optional<rpc_clock_type::duration> handler_duration) {
+inline future<> reply(wait_type, future<RetTypes>&& ret, uint64_t, int64_t msg_id, shared_ptr<server::connection> client,
+        internal::reply_handle reply_handle, std::optional<rpc_clock_type::time_point> timeout, std::optional<rpc_clock_type::duration> handler_duration) {
     if (!client->error()) {
         snd_buf data;
         try {
@@ -635,7 +638,7 @@ inline future<> reply(wait_type, future<RetTypes>&& ret, uint64_t verb, int64_t 
             msg_id = -msg_id;
         }
 
-        return client->respond(msg_id, std::move(data), timeout, handler_duration);
+        return client->respond(std::move(reply_handle), msg_id, std::move(data), timeout, handler_duration);
     } else {
         ret.ignore_ready_future();
         return make_ready_future<>();
@@ -645,11 +648,14 @@ inline future<> reply(wait_type, future<RetTypes>&& ret, uint64_t verb, int64_t 
 // specialization for no_wait_type which does not send a reply
 template<typename Serializer>
 inline future<> reply(no_wait_type, future<no_wait_type>&& r, uint64_t verb, int64_t msgid, shared_ptr<server::connection> client,
-        std::optional<rpc_clock_type::time_point>, std::optional<rpc_clock_type::duration>) {
+        internal::reply_handle reply_handle, std::optional<rpc_clock_type::time_point>, std::optional<rpc_clock_type::duration>) {
     try {
         r.get();
     } catch (std::exception& ex) {
         client->get_logger()(client->info(), msgid, format("exception \"{}\" in no_wait handler of the verb {} ignored", ex.what(), verb));
+    }
+    if (reply_handle.close) {
+        return reply_handle.close();
     }
     return make_ready_future<>();
 }
@@ -681,28 +687,29 @@ auto recv_helper(uint64_t verb, signature<Ret (InArgs...)> sig, Func&& func, Wan
                                                                  std::optional<rpc_clock_type::time_point> timeout,
                                                                  int64_t msg_id,
                                                                  rcv_buf data,
+                                                                 internal::reply_handle reply_handle,
                                                                  gate::holder guard) mutable {
         auto memory_consumed = client->estimate_request_size(data.size);
         if (memory_consumed > client->max_request_size()) {
             auto err = format("request size {:d} large than memory limit {:d}, verb {}", memory_consumed, client->max_request_size(), verb);
             client->get_logger()(client->peer_address(), err);
             // FIXME: future is discarded
-            (void)try_with_gate(client->get_server().reply_gate(), [verb, client, timeout, msg_id, err = std::move(err)] {
-                return reply<Serializer>(wait_style(), futurize<Ret>::make_exception_future(std::runtime_error(err.c_str())), verb, msg_id, client, timeout, std::nullopt).handle_exception([verb, client, msg_id] (std::exception_ptr eptr) {
+            (void)try_with_gate(client->get_server().reply_gate(), [verb, client, timeout, msg_id, err = std::move(err), reply_handle = std::move(reply_handle)] () mutable {
+                return reply<Serializer>(wait_style(), futurize<Ret>::make_exception_future(std::runtime_error(err.c_str())), verb, msg_id, client, std::move(reply_handle), timeout, std::nullopt).handle_exception([verb, client, msg_id] (std::exception_ptr eptr) {
                     client->get_logger()(client->info(), msg_id, seastar::format("got exception while processing an oversized message: {} for verb {}", eptr, verb));
                 });
             }).handle_exception_type([] (gate_closed_exception&) {/* ignore */});
             return make_ready_future();
         }
         // note: apply is executed asynchronously with regards to networking so we cannot chain futures here by doing "return apply()"
-        auto f = client->wait_for_resources(memory_consumed, timeout).then([verb, client, timeout, msg_id, data = std::move(data), &func, g = std::move(guard)] (auto permit) mutable {
+        auto f = client->wait_for_resources(memory_consumed, timeout).then([verb, client, timeout, msg_id, data = std::move(data), reply_handle = std::move(reply_handle), &func, g = std::move(guard)] (auto permit) mutable {
                 // FIXME: future is discarded
-                (void)try_with_gate(client->get_server().reply_gate(), [verb, client, timeout, msg_id, data = std::move(data), permit = std::move(permit), &func] () mutable {
+                (void)try_with_gate(client->get_server().reply_gate(), [verb, client, timeout, msg_id, data = std::move(data), permit = std::move(permit), reply_handle = std::move(reply_handle), &func] () mutable {
                     try {
                         auto args = unmarshall<Serializer, InArgs...>(*client, std::move(data));
                         auto start = rpc_clock_type::now();
-                        return apply(func, client->info(), timeout, WantClientInfo(), WantTimePoint(), signature(), std::move(args)).then_wrapped([verb, client, timeout, msg_id, permit = std::move(permit), start] (futurize_t<Ret> ret) mutable {
-                            return reply<Serializer>(wait_style(), std::move(ret), verb, msg_id, client, timeout, rpc_clock_type::now() - start).handle_exception([verb, permit = std::move(permit), client, msg_id] (std::exception_ptr eptr) {
+                        return apply(func, client->info(), timeout, WantClientInfo(), WantTimePoint(), signature(), std::move(args)).then_wrapped([verb, client, timeout, msg_id, permit = std::move(permit), reply_handle = std::move(reply_handle), start] (futurize_t<Ret> ret) mutable {
+                            return reply<Serializer>(wait_style(), std::move(ret), verb, msg_id, client, std::move(reply_handle), timeout, rpc_clock_type::now() - start).handle_exception([verb, permit = std::move(permit), client, msg_id] (std::exception_ptr eptr) {
                                 client->get_logger()(client->info(), msg_id, seastar::format("got exception while processing a message: {}, verb {}", eptr, verb));
                             });
                         });
@@ -1013,5 +1020,3 @@ struct hash<seastar::rpc::streaming_domain_type> {
     }
 };
 }
-
-

--- a/include/seastar/rpc/rpc_quic_transport.hh
+++ b/include/seastar/rpc/rpc_quic_transport.hh
@@ -22,24 +22,6 @@
 #include <seastar/quic/quic.hh>
 #include <seastar/rpc/rpc.hh>
 
-namespace seastar::rpc {
-
-class connected_socket_transport final : public connection::transport {
-    connected_socket _fd;
-    input_stream<char> _input;
-    output_stream<char> _output;
-
-public:
-    explicit connected_socket_transport(connected_socket fd) noexcept;
-
-    input_stream<char>& input() override;
-    output_stream<char>& output() override;
-    void shutdown_input() override;
-    void shutdown_output() override;
-};
-
-} // namespace seastar::rpc
-
 namespace seastar::rpc::experimental {
 
 std::unique_ptr<server::acceptor> make_quic_server_acceptor(seastar::quic::experimental::quic_server_config config);
@@ -59,6 +41,7 @@ public:
     void shutdown_input() override;
     void shutdown_output() override;
     future<> stop() override;
+    bool is_closed_exception(std::exception_ptr ep) const noexcept override;
     bool supports_multiplexed_requests() const override;
     future<std::unique_ptr<connection::transport::stream>> open_request_stream() override;
 
@@ -81,6 +64,7 @@ public:
     void shutdown_input() override;
     void shutdown_output() override;
     future<> stop() override;
+    bool is_closed_exception(std::exception_ptr ep) const noexcept override;
     bool supports_multiplexed_requests() const override;
     future<std::unique_ptr<connection::transport::stream>> accept_request_stream() override;
 

--- a/include/seastar/rpc/rpc_quic_transport.hh
+++ b/include/seastar/rpc/rpc_quic_transport.hh
@@ -1,0 +1,135 @@
+/*
+ * This file is open source software, licensed to you under the terms
+ * of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+
+#include <seastar/core/coroutine.hh>
+#include <seastar/quic/quic_client.hh>
+#include <seastar/quic/quic_server.hh>
+#include <seastar/quic/quic.hh>
+#include <seastar/rpc/rpc.hh>
+
+namespace seastar::rpc {
+
+class connected_socket_transport final : public connection::transport {
+    connected_socket _fd;
+    input_stream<char> _input;
+    output_stream<char> _output;
+
+public:
+    explicit connected_socket_transport(connected_socket fd) noexcept;
+
+    input_stream<char>& input() override;
+    output_stream<char>& output() override;
+    void shutdown_input() override;
+    void shutdown_output() override;
+};
+
+} // namespace seastar::rpc
+
+namespace seastar::rpc::experimental {
+
+std::unique_ptr<server::acceptor> make_quic_server_acceptor(seastar::quic::experimental::quic_server_config config);
+
+class quic_client_transport final : public connection::transport {
+public:
+    quic_client_transport(
+            seastar::quic::experimental::quic_client client,
+            seastar::quic::experimental::connection conn,
+            seastar::quic::experimental::stream control_stream);
+    quic_client_transport(
+            seastar::quic::experimental::connection conn,
+            seastar::quic::experimental::stream control_stream);
+
+    input_stream<char>& input() override;
+    output_stream<char>& output() override;
+    void shutdown_input() override;
+    void shutdown_output() override;
+    future<> stop() override;
+    bool supports_multiplexed_requests() const override;
+    future<std::unique_ptr<connection::transport::stream>> open_request_stream() override;
+
+private:
+    std::optional<seastar::quic::experimental::quic_client> _client;
+    seastar::quic::experimental::connection _conn;
+    seastar::quic::experimental::stream _control_stream;
+    input_stream<char> _control_input;
+    output_stream<char> _control_output;
+};
+
+class quic_server_transport final : public connection::transport {
+public:
+    quic_server_transport(
+            seastar::quic::experimental::connection conn,
+            seastar::quic::experimental::stream control_stream);
+
+    input_stream<char>& input() override;
+    output_stream<char>& output() override;
+    void shutdown_input() override;
+    void shutdown_output() override;
+    future<> stop() override;
+    bool supports_multiplexed_requests() const override;
+    future<std::unique_ptr<connection::transport::stream>> accept_request_stream() override;
+
+private:
+    seastar::quic::experimental::connection _conn;
+    seastar::quic::experimental::stream _control_stream;
+    input_stream<char> _control_input;
+    output_stream<char> _control_output;
+};
+
+} // namespace seastar::rpc::experimental
+
+namespace seastar::rpc {
+
+template <typename Serializer, typename MsgType>
+future<std::unique_ptr<typename protocol<Serializer, MsgType>::client>>
+protocol<Serializer, MsgType>::make_quic_client(quic::experimental::quic_client_config config) {
+    return make_quic_client(client_options{}, std::move(config));
+}
+
+template <typename Serializer, typename MsgType>
+future<std::unique_ptr<typename protocol<Serializer, MsgType>::client>>
+protocol<Serializer, MsgType>::make_quic_client(client_options options, quic::experimental::quic_client_config config) {
+    quic::experimental::quic_client quic_client;
+    auto session = co_await quic_client.connect(std::move(config));
+    auto peer_addr = session.peer_address();
+    auto local_addr = session.local_address();
+    auto control_stream = co_await session.open_stream();
+    auto transport = std::make_unique<experimental::quic_client_transport>(
+            std::move(quic_client),
+            std::move(session),
+            std::move(control_stream));
+
+    co_return std::make_unique<typename protocol<Serializer, MsgType>::client>(
+            *this,
+            std::move(options),
+            std::move(transport),
+            peer_addr,
+            local_addr);
+}
+
+template <typename Serializer, typename MsgType>
+protocol<Serializer, MsgType>::server::server(protocol& proto, quic::experimental::quic_server_config config, resource_limits memory_limit)
+        : rpc::server(&proto, experimental::make_quic_server_acceptor(std::move(config)), memory_limit) {
+}
+
+template <typename Serializer, typename MsgType>
+protocol<Serializer, MsgType>::server::server(protocol& proto, server_options opts, quic::experimental::quic_server_config config, resource_limits memory_limit)
+        : rpc::server(&proto, std::move(opts), experimental::make_quic_server_acceptor(std::move(config)), memory_limit) {
+}
+
+} // namespace seastar::rpc

--- a/include/seastar/rpc/rpc_types.hh
+++ b/include/seastar/rpc/rpc_types.hh
@@ -226,11 +226,21 @@ struct cancellable {
         return *this;
     }
     void cancel() {
-        if (cancel_send) {
-            cancel_send();
+        auto cs = std::exchange(cancel_send, std::function<void()>{});
+        auto cw = std::exchange(cancel_wait, std::function<void()>{});
+        if (send_back_pointer) {
+            *send_back_pointer = nullptr;
         }
-        if (cancel_wait) {
-            cancel_wait();
+        if (wait_back_pointer) {
+            *wait_back_pointer = nullptr;
+        }
+        send_back_pointer = nullptr;
+        wait_back_pointer = nullptr;
+        if (cs) {
+            cs();
+        }
+        if (cw) {
+            cw();
         }
     }
     ~cancellable() {

--- a/src/quic/quic_client.cc
+++ b/src/quic/quic_client.cc
@@ -945,10 +945,19 @@ int stream_stop_sending_cb(ngtcp2_conn* conn, int64_t sid, uint64_t app_error_co
     return 0;
 }
 
-int stream_close_cb(ngtcp2_conn*, uint32_t, int64_t sid, uint64_t, void* user_data, void*) {
+int stream_close_cb(ngtcp2_conn* conn, uint32_t, int64_t sid, uint64_t, void* user_data, void*) {
     auto* st = static_cast<client_state*>(user_data);
     if (!st || !st->connection_state) {
         return 0;
+    }
+
+    auto peer_initiated = !ngtcp2_conn_is_local_stream(conn, sid);
+    if (peer_initiated) {
+        if (ngtcp2_is_bidi_stream(sid)) {
+            ngtcp2_conn_extend_max_streams_bidi(conn, 1);
+        } else {
+            ngtcp2_conn_extend_max_streams_uni(conn, 1);
+        }
     }
 
     st->release_stream_data(sid);

--- a/src/quic/quic_server.cc
+++ b/src/quic/quic_server.cc
@@ -1126,10 +1126,19 @@ private:
         return 0;
     }
 
-    static int stream_close_cb(ngtcp2_conn*, uint32_t, int64_t sid, uint64_t, void* user_data, void*) {
+    static int stream_close_cb(ngtcp2_conn* ngconn, uint32_t, int64_t sid, uint64_t, void* user_data, void*) {
         auto* conn = static_cast<server_connection*>(user_data);
         if (!conn || !conn->connection_state) {
             return 0;
+        }
+
+        auto peer_initiated = !ngtcp2_conn_is_local_stream(ngconn, sid);
+        if (peer_initiated) {
+            if (ngtcp2_is_bidi_stream(sid)) {
+                ngtcp2_conn_extend_max_streams_bidi(ngconn, 1);
+            } else {
+                ngtcp2_conn_extend_max_streams_uni(ngconn, 1);
+            }
         }
 
         conn->release_stream_data(sid);

--- a/src/rpc/rpc.cc
+++ b/src/rpc/rpc.cc
@@ -137,6 +137,87 @@ static void log_exception(connection& c, log_level level, const char* log, std::
     c.get_logger()(c.peer_address(), level, std::string_view(formatted.data(), formatted.size()));
 }
 
+static future<> write_snd_buf(output_stream<char>& out, snd_buf buf) {
+    auto* b = std::get_if<temporary_buffer<char>>(&buf.bufs);
+    if (b) {
+        return out.write(std::move(*b));
+    } else {
+        return do_with(std::move(std::get<std::vector<temporary_buffer<char>>>(buf.bufs)),
+                [&out] (std::vector<temporary_buffer<char>>& ar) {
+            return do_for_each(ar.begin(), ar.end(), [&out] (auto& b) {
+                return out.write(std::move(b));
+            });
+        });
+    }
+}
+
+class connected_socket_transport final : public connection::transport {
+    connected_socket _fd;
+    input_stream<char> _input;
+    output_stream<char> _output;
+
+public:
+    explicit connected_socket_transport(connected_socket fd) noexcept
+        : _fd(std::move(fd))
+        , _input(_fd.input())
+        , _output(_fd.output()) {
+    }
+
+    input_stream<char>& input() override {
+        return _input;
+    }
+
+    output_stream<char>& output() override {
+        return _output;
+    }
+
+    void shutdown_input() override {
+        _fd.shutdown_input();
+    }
+
+    void shutdown_output() override {
+        _fd.shutdown_output();
+    }
+};
+
+namespace internal {
+
+class send_cancellation_state {
+    cancellable* _cancel = nullptr;
+    bool _cancelled = false;
+
+public:
+    void attach(cancellable& cancel, lw_shared_ptr<send_cancellation_state> self) {
+        cancel.cancel_send = [self] {
+            self->_cancelled = true;
+        };
+        cancel.send_back_pointer = &_cancel;
+        _cancel = &cancel;
+    }
+
+    bool cancelled() const noexcept {
+        return _cancelled;
+    }
+
+    cancellable* cancel() const noexcept {
+        return _cancel;
+    }
+
+    void uncancellable() noexcept {
+        if (_cancel) {
+            _cancel->cancel_send = std::function<void()>();
+            _cancel->send_back_pointer = nullptr;
+            _cancel = nullptr;
+        }
+    }
+
+    ~send_cancellation_state() {
+        uncancellable();
+    }
+};
+
+} // namespace internal
+
 snd_buf connection::compress(snd_buf buf) {
     if (_compressor) {
         buf = _compressor->compress(4, std::move(buf));
@@ -148,17 +229,7 @@ snd_buf connection::compress(snd_buf buf) {
 }
 
 future<> connection::send_buffer(snd_buf buf) {
-    auto* b = std::get_if<temporary_buffer<char>>(&buf.bufs);
-    if (b) {
-        return _connected->write_buf.write(std::move(*b));
-    } else {
-        return do_with(std::move(std::get<std::vector<temporary_buffer<char>>>(buf.bufs)),
-                [this] (std::vector<temporary_buffer<char>>& ar) {
-            return do_for_each(ar.begin(), ar.end(), [this] (auto& b) {
-                return _connected->write_buf.write(std::move(b));
-            });
-        });
-    }
+    return write_snd_buf(transport_output(), std::move(buf));
 }
 
 future<> connection::send_entry(outgoing_entry& d) noexcept {
@@ -186,7 +257,7 @@ future<> connection::send_entry(outgoing_entry& d) noexcept {
         auto buf = compress(std::move(d.buf));
         return send_buffer(std::move(buf)).then([this] {
             _stats.sent_messages++;
-            return _connected->write_buf.flush();
+            return transport_output().flush();
         });
     });
 }
@@ -198,9 +269,7 @@ void connection::set_negotiated() noexcept {
 
 future<> connection::stop_send_loop(std::exception_ptr ex) {
     _error = true;
-    if (_connected) {
-        _connected->fd.shutdown_output();
-    }
+    shutdown_transport_output();
     if (ex == nullptr) {
         ex = std::make_exception_ptr(closed_error());
     }
@@ -229,15 +298,29 @@ future<> connection::stop_send_loop(std::exception_ptr ex) {
         std::get<0>(res).ignore_ready_future();
         // _sink_closed_future is never exceptional
         bool sink_closed = std::get<1>(res).get();
-        return _connected && !sink_closed ? _connected->write_buf.close() : make_ready_future();
+        return connected() && !sink_closed ? transport_output().close() : make_ready_future();
     });
 }
 
 void connection::set_socket(connected_socket&& fd) {
-    if (_connected.has_value()) {
+    set_transport(std::make_unique<connected_socket_transport>(std::move(fd)));
+}
+
+void connection::set_transport(std::unique_ptr<transport> t) {
+    if (_transport) {
         throw std::runtime_error("already connected");
     }
-    _connected.emplace(std::move(fd));
+    _transport = std::move(t);
+}
+
+internal::reply_handle connection::make_reply_handle() {
+    return internal::reply_handle([this] (snd_buf&& data, std::optional<rpc_clock_type::time_point> timeout) {
+        return send(std::move(data), timeout);
+    });
+}
+
+future<internal::incoming_request> connection::receive_request_frame(input_stream<char>&) {
+    return make_exception_future<internal::incoming_request>(std::runtime_error("transport does not support receiving RPC requests"));
 }
 
 future<> connection::send_negotiation_frame(feature_map features) {
@@ -258,9 +341,9 @@ future<> connection::send_negotiation_frame(feature_map features) {
         p += 4;
         p = std::copy_n(e.second.begin(), e.second.size(), p);
     }
-    return _connected->write_buf.write(std::move(reply)).then([this] {
+    return transport_output().write(std::move(reply)).then([this] {
         _stats.sent_messages++;
-        return _connected->write_buf.flush();
+        return transport_output().flush();
     });
 }
 
@@ -347,7 +430,7 @@ future<> connection::send(snd_buf buf, std::optional<rpc_clock_type::time_point>
 void connection::abort() {
     if (!_error) {
         _error = true;
-        _connected->fd.shutdown_input();
+        shutdown_transport_input();
     }
 }
 
@@ -553,7 +636,7 @@ future<> connection::stream_close() {
         _sink_closed_future = p.get_future();
         // stop_send_loop(), which also calls _write_buf.close(), and this code can run in parallel.
         // Use _sink_closed_future to serialize them and skip second call to close()
-        f = _connected->write_buf.close().finally([p = std::move(p)] () mutable { p.set_value(true);});
+        f = transport_output().close().finally([p = std::move(p)] () mutable { p.set_value(true);});
     }
     return f.finally([this] () mutable { return stop(); });
 }
@@ -569,7 +652,7 @@ future<> connection::stream_process_incoming(rcv_buf&& buf) {
 }
 
 future<> connection::handle_stream_frame() {
-    return read_stream_frame_compressed(_connected->read_buf).then([this] (std::optional<rcv_buf> data) {
+    return read_stream_frame_compressed(transport_input()).then([this] (std::optional<rcv_buf> data) {
         if (!data) {
             _error = true;
             return make_ready_future<>();
@@ -665,8 +748,92 @@ struct request_frame_with_timeout : request_frame {
     }
 };
 
-future<> client::request(uint64_t type, int64_t msg_id, snd_buf buf, std::optional<rpc_clock_type::time_point> timeout, cancellable* cancel) {
+template <typename FrameType>
+future<request_frame::return_type>
+read_quic_request_frame_uncompressed(server::connection& owner, input_stream<char>& in) {
+    auto header_size = FrameType::header_size();
+    auto header = co_await in.read_exactly(header_size);
+    if (header.size() != header_size) {
+        if (header.size() != 0) {
+            owner.get_logger()(owner.peer_address(), format(
+                    "dropping truncated QUIC request stream header: expected {:d} got {:d}",
+                    header_size, header.size()));
+        }
+        co_return FrameType::empty_value();
+    }
+
+    auto [size, h] = FrameType::decode_header(header.get());
+    if (owner.estimate_request_size(size) > owner.max_request_size()) {
+        owner.get_logger()(owner.peer_address(), format(
+                "dropping invalid QUIC request stream: payload size {:d} exceeds memory limit {:d}",
+                size, owner.max_request_size()));
+        co_return FrameType::empty_value();
+    }
+
+    if (!size) {
+        co_return FrameType::make_value(h, rcv_buf());
+    }
+
+    auto rb = co_await read_rcv_buf(in, size);
+    if (rb.size != size) {
+        owner.get_logger()(owner.peer_address(), format(
+                "dropping truncated QUIC request stream data: expected {:d} got {:d}",
+                size, rb.size));
+        co_return FrameType::empty_value();
+    }
+
+    co_return FrameType::make_value(h, std::move(rb));
+}
+
+template <typename FrameType>
+future<request_frame::return_type>
+read_quic_request_frame_compressed(server::connection& owner, std::unique_ptr<compressor>& compressor, input_stream<char>& in) {
+    auto compress_header = co_await in.read_exactly(sizeof(uint32_t));
+    if (compress_header.size() != sizeof(uint32_t)) {
+        if (compress_header.size() != 0) {
+            owner.get_logger()(owner.peer_address(), format(
+                    "dropping truncated compressed QUIC request stream header: expected {:d} got {:d}",
+                    sizeof(uint32_t), compress_header.size()));
+        }
+        co_return FrameType::empty_value();
+    }
+
+    auto ptr = compress_header.get();
+    auto compressed_size = read_le<uint32_t>(ptr);
+    if (owner.estimate_request_size(compressed_size) > owner.max_request_size()) {
+        owner.get_logger()(owner.peer_address(), format(
+                "dropping invalid compressed QUIC request stream: compressed payload size {:d} exceeds memory limit {:d}",
+                compressed_size, owner.max_request_size()));
+        co_return FrameType::empty_value();
+    }
+
+    auto compressed_data = co_await read_rcv_buf(in, compressed_size);
+    if (compressed_data.size != compressed_size) {
+        owner.get_logger()(owner.peer_address(), format(
+                "dropping truncated compressed QUIC request stream data: expected {:d} got {:d}",
+                compressed_size, compressed_data.size));
+        co_return FrameType::empty_value();
+    }
+
+    auto decompressed = compressor->decompress(std::move(compressed_data));
+    if (decompressed.size == 0) {
+        co_return FrameType::empty_value();
+    }
+
+    auto source = std::visit([] (auto&& b) {
+        return util::as_input_stream(std::move(b));
+    }, decompressed.bufs);
+    auto frame = co_await do_with(std::move(source), [&owner] (input_stream<char>& decompressed_in) {
+        return read_quic_request_frame_uncompressed<FrameType>(owner, decompressed_in);
+    });
+    co_return frame;
+}
+
+future<> client::request(uint64_t type, int64_t msg_id, snd_buf buf, std::optional<rpc_clock_type::time_point> timeout, cancellable* cancel, bool expect_response) {
     request_frame_with_timeout::encode_header(type, msg_id, buf);
+    if (_transport && _transport->supports_multiplexed_requests()) {
+        return send_multiplexed_request(msg_id, std::move(buf), timeout, cancel, expect_response);
+    }
     return send(std::move(buf), timeout, cancel);
 }
 
@@ -704,7 +871,7 @@ client::negotiate(feature_map provided) {
 
 future<> client::negotiate_protocol(feature_map features) {
     return send_negotiation_frame(std::move(features)).then([this] {
-        return receive_negotiation_frame(*this, _connected->read_buf).then([this] (feature_map features) {
+        return receive_negotiation_frame(*this, transport_input()).then([this] (feature_map features) {
             return negotiate(std::move(features));
         });
     });
@@ -791,6 +958,223 @@ client::read_response_frame_compressed(input_stream<char>& in) {
     }
 }
 
+future<internal::incoming_response>
+client::receive_response_frame(input_stream<char>& in) {
+    auto [msg_id, handler_duration, data] = co_await read_response_frame_compressed(in);
+    co_return internal::incoming_response{
+        .msg_id = msg_id,
+        .handler_duration = handler_duration,
+        .data = std::move(data),
+    };
+}
+
+future<internal::incoming_response>
+client::receive_response() {
+    return receive_response_frame(transport_input());
+}
+
+void client::handle_response(internal::incoming_response response) {
+    auto msg_id = response.msg_id;
+    auto it = _outstanding.find(std::abs(msg_id));
+    if (!response.data) {
+        _error = true;
+    } else if (it != _outstanding.end()) {
+        auto handler = std::move(it->second);
+        _outstanding.erase(it);
+        (*handler)(*this, msg_id, std::move(response.data.value()));
+        if (response.handler_duration) {
+            _stats.delay_samples++;
+            _stats.delay_total += (rpc_clock_type::now() - handler->start) - std::chrono::microseconds(*response.handler_duration);
+        }
+    } else if (msg_id < 0) {
+        try {
+            std::rethrow_exception(unmarshal_exception(response.data.value()));
+        } catch(const unknown_verb_error& ex) {
+            // if this is unknown verb exception with unknown id ignore it
+            // can happen if unknown verb was used by no_wait client
+            get_logger()(peer_address(), format("unknown verb exception {:d} ignored", ex.type));
+        } catch(...) {
+            // We've got error response but handler is no longer waiting, could be timed out.
+            log_exception(*this, log_level::info, "ignoring error response", std::current_exception());
+        }
+    } else {
+        // we get a reply for a message id not in _outstanding
+        // this can happened if the message id is timed out already
+        get_logger()(peer_address(), log_level::debug, "got a reply for an expired message id");
+    }
+}
+
+bool client::can_send_request(id_type id, bool expect_response) const {
+    return !expect_response || _outstanding.find(id) != _outstanding.end();
+}
+
+bool client::close_outstanding_request(id_type id) {
+    auto it = _outstanding.find(id);
+    if (it == _outstanding.end()) {
+        return false;
+    }
+    auto handler = std::move(it->second);
+    _outstanding.erase(it);
+    handler->closed();
+    return true;
+}
+
+lw_shared_ptr<client::multiplexed_request_state> client::register_multiplexed_request(id_type id) {
+    auto state = make_lw_shared<multiplexed_request_state>();
+    _active_multiplexed_requests.emplace(id, state);
+    return state;
+}
+
+void client::cleanup_multiplexed_request(id_type id, lw_shared_ptr<multiplexed_request_state> request_state) {
+    auto it = _active_multiplexed_requests.find(id);
+    if (it != _active_multiplexed_requests.end() && it->second.get() == request_state.get()) {
+        _active_multiplexed_requests.erase(it);
+    }
+}
+
+void client::abort_multiplexed_request(id_type id) noexcept {
+    auto it = _active_multiplexed_requests.find(id);
+    if (it == _active_multiplexed_requests.end()) {
+        return;
+    }
+    auto state = it->second;
+    state->cancelled = true;
+    if (state->stream) {
+        auto close = state->request_sent ? state->stream->stop_input() : state->stream->abort();
+        (void)std::move(close).finally([state] {}).handle_exception([] (std::exception_ptr) {});
+    }
+}
+
+void client::abort_all_multiplexed_requests() noexcept {
+    for (auto& request : _active_multiplexed_requests) {
+        auto state = request.second;
+        state->cancelled = true;
+        if (state->stream) {
+            auto close = state->request_sent ? state->stream->stop_input() : state->stream->abort();
+            (void)std::move(close).finally([state] {}).handle_exception([] (std::exception_ptr) {});
+        }
+    }
+}
+
+void client::handle_multiplexed_response(id_type msg_id, internal::incoming_response response) {
+    if (!response.data) {
+        close_outstanding_request(msg_id);
+        return;
+    }
+    handle_response(std::move(response));
+}
+
+future<> client::send_multiplexed_request(int64_t msg_id, snd_buf buf, std::optional<rpc_clock_type::time_point> timeout, cancellable* cancel, bool expect_response) {
+    if (timeout && *timeout <= rpc_clock_type::now()) {
+        return make_ready_future<>();
+    }
+
+    auto cancel_state = make_lw_shared<internal::send_cancellation_state>();
+    if (cancel) {
+        cancel_state->attach(*cancel, cancel_state);
+    }
+    auto request_state = register_multiplexed_request(msg_id);
+
+    if (_negotiated) {
+        return _negotiated->get_shared_future().then([this, msg_id, buf = std::move(buf), timeout, cancel_state, expect_response, request_state] () mutable {
+            return do_send_multiplexed_request(msg_id, std::move(buf), timeout, std::move(cancel_state), expect_response, std::move(request_state));
+        }).handle_exception([this, msg_id, request_state] (std::exception_ptr ep) {
+            cleanup_multiplexed_request(msg_id, request_state);
+            return make_exception_future<>(ep);
+        });
+    }
+    return do_send_multiplexed_request(msg_id, std::move(buf), timeout, std::move(cancel_state), expect_response, std::move(request_state));
+}
+
+future<> client::do_send_multiplexed_request(int64_t msg_id, snd_buf data, std::optional<rpc_clock_type::time_point> timeout, lw_shared_ptr<internal::send_cancellation_state> cancel_state, bool expect_response, lw_shared_ptr<multiplexed_request_state> request_state) {
+    if (request_state->cancelled || cancel_state->cancelled() || (timeout && *timeout <= rpc_clock_type::now())) {
+        cleanup_multiplexed_request(msg_id, request_state);
+        co_return;
+    }
+    if (!can_send_request(msg_id, expect_response)) {
+        cleanup_multiplexed_request(msg_id, request_state);
+        co_return;
+    }
+
+    if (data.size && _propagate_timeout) {
+        static_assert(snd_buf::chunk_size >= sizeof(uint64_t), "send buffer chunk size is too small");
+        if (_timeout_negotiated) {
+            uint64_t left = 0;
+            if (timeout) {
+                left = std::chrono::duration_cast<std::chrono::milliseconds>(*timeout - rpc_clock_type::now()).count();
+            }
+            write_le<uint64_t>(data.front().get_write(), left);
+        } else {
+            data.front().trim_front(sizeof(uint64_t));
+            data.size -= sizeof(uint64_t);
+        }
+    }
+    data = compress(std::move(data));
+
+    try {
+        request_state->stream = co_await _transport->open_request_stream();
+        if (request_state->cancelled
+                || cancel_state->cancelled()
+                || (timeout && *timeout <= rpc_clock_type::now())
+                || !can_send_request(msg_id, expect_response)) {
+            co_await request_state->stream->abort();
+            cleanup_multiplexed_request(msg_id, request_state);
+            co_return;
+        }
+        cancel_state->uncancellable();
+
+        co_await write_snd_buf(request_state->stream->output(), std::move(data));
+        _stats.sent_messages++;
+        co_await request_state->stream->close_output();
+        request_state->request_sent = true;
+
+        if (!expect_response) {
+            (void)with_gate(_response_gate, [this, msg_id, request_state] {
+                return request_state->stream->drain_input().handle_exception([] (std::exception_ptr) {
+                }).finally([this, msg_id, request_state] {
+                    cleanup_multiplexed_request(msg_id, request_state);
+                });
+            });
+            co_return;
+        }
+
+        if (!can_send_request(msg_id, expect_response)) {
+            co_await request_state->stream->abort();
+            cleanup_multiplexed_request(msg_id, request_state);
+            co_return;
+        }
+
+        (void)with_gate(_response_gate, [this, msg_id, request_state] {
+            return receive_response_frame(request_state->stream->input()).then([this, msg_id] (internal::incoming_response response) {
+                handle_multiplexed_response(msg_id, std::move(response));
+            }).handle_exception([this, msg_id] (std::exception_ptr ep) {
+                if (close_outstanding_request(msg_id)) {
+                    if (!error()) {
+                        log_exception(*this, log_level::error, "client multiplexed request stream failed", ep);
+                    }
+                }
+            }).finally([this, msg_id, request_state] {
+                return request_state->stream->drain_input().handle_exception([] (std::exception_ptr) {
+                }).finally([this, msg_id, request_state] {
+                    cleanup_multiplexed_request(msg_id, request_state);
+                });
+            });
+        });
+    } catch (gate_closed_exception&) {
+        cleanup_multiplexed_request(msg_id, request_state);
+        if (expect_response) {
+            close_outstanding_request(msg_id);
+        }
+        throw closed_error();
+    } catch (...) {
+        cleanup_multiplexed_request(msg_id, request_state);
+        if (expect_response) {
+            close_outstanding_request(msg_id);
+        }
+        throw;
+    }
+}
+
 stats client::get_stats() const {
     stats res = _stats;
     res.wait_reply = incoming_queue_length();
@@ -805,8 +1189,13 @@ void client::wait_for_reply(id_type id, std::unique_ptr<reply_handler_base>&& h,
     }
     if (cancel) {
         cancel->cancel_wait = [this, id] {
-            _outstanding[id]->cancel();
-            _outstanding.erase(id);
+            abort_multiplexed_request(id);
+            auto it = _outstanding.find(id);
+            if (it == _outstanding.end()) {
+                return;
+            }
+            it->second->cancel();
+            _outstanding.erase(it);
         };
         h->pcancel = cancel;
         cancel->wait_back_pointer = &h->pcancel;
@@ -815,18 +1204,30 @@ void client::wait_for_reply(id_type id, std::unique_ptr<reply_handler_base>&& h,
 }
 void client::wait_timed_out(id_type id) {
     _stats.timeout++;
-    _outstanding[id]->timeout();
-    _outstanding.erase(id);
+    auto it = _outstanding.find(id);
+    if (it == _outstanding.end()) {
+        return;
+    }
+    abort_multiplexed_request(id);
+    it->second->timeout();
+    _outstanding.erase(it);
 }
 
 future<> client::stop() noexcept {
     _error = true;
+    future<> transport_stopped = make_ready_future<>();
     try {
+        if (_transport) {
+            transport_stopped = _transport->stop();
+        } else {
+            shutdown_transport_input();
+            shutdown_transport_output();
+        }
         _socket.shutdown();
     } catch(...) {
         log_exception(*this, log_level::error, "fail to shutdown connection while stopping", std::current_exception());
     }
-    return _stopped.get_future();
+    return when_all_succeed(std::move(transport_stopped), _stopped.get_future()).discard_result();
 }
 
 void client::abort_all_streams() {
@@ -958,75 +1359,67 @@ client::client(const logger& l, void* s, client_options ops, socket socket, cons
     enqueue_zero_frame();
 }
 
-future<> client::loop(client_options ops, const socket_address& addr, const socket_address& local) {
+client::client(const logger& l, void* s, client_options ops, std::unique_ptr<transport> transport, const socket_address& addr, const socket_address& local)
+        : rpc::connection(l, s), _socket(make_socket()), _server_addr(addr), _local_addr(local), _options(ops), _metrics(*this)
+{
+    set_transport(std::move(transport));
+    // Run client in the background.
+    // Communicate result via _stopped.
+    // The caller has to call client::stop() to synchronize.
+    (void)loop_with_transport();
+    enqueue_zero_frame();
+}
+
+feature_map client::make_client_features() const {
+    feature_map features;
+    if (_options.compressor_factory) {
+        features[protocol_features::COMPRESS] = _options.compressor_factory->supported();
+    }
+    if (_options.send_timeout_data) {
+        features[protocol_features::TIMEOUT] = "";
+    }
+    if (_options.send_handler_duration) {
+        features[protocol_features::HANDLER_DURATION] = "";
+    }
+    if (_options.stream_parent) {
+        features[protocol_features::STREAM_PARENT] = serialize_connection_id(_options.stream_parent);
+    }
+    if (!_options.isolation_cookie.empty()) {
+        features[protocol_features::ISOLATION] = _options.isolation_cookie;
+    }
+    return features;
+}
+
+future<> client::process_client_connection() {
+    co_await negotiate_protocol(make_client_features());
+
+    _propagate_timeout = !is_stream();
+    set_negotiated();
+    while (!transport_input().eof() && !_error) {
+        if (is_stream()) {
+            co_await handle_stream_frame();
+            continue;
+        }
+
+        if (_transport->supports_multiplexed_requests()) {
+            co_await transport_input().read();
+        } else {
+            auto response = co_await receive_response();
+            handle_response(std::move(response));
+        }
+    }
+}
+
+future<> client::loop_with_transport() {
     std::exception_ptr ep;
     try {
-        connected_socket fd = co_await _socket.connect(addr, local);
-        fd.set_nodelay(ops.tcp_nodelay);
-        if (ops.keepalive) {
-            fd.set_keepalive(true);
-            fd.set_keepalive_parameters(ops.keepalive.value());
-        }
-        set_socket(std::move(fd));
-
-        feature_map features;
-        if (_options.compressor_factory) {
-            features[protocol_features::COMPRESS] = _options.compressor_factory->supported();
-        }
-        if (_options.send_timeout_data) {
-            features[protocol_features::TIMEOUT] = "";
-        }
-        if (_options.send_handler_duration) {
-            features[protocol_features::HANDLER_DURATION] = "";
-        }
-        if (_options.stream_parent) {
-            features[protocol_features::STREAM_PARENT] = serialize_connection_id(_options.stream_parent);
-        }
-        if (!_options.isolation_cookie.empty()) {
-            features[protocol_features::ISOLATION] = _options.isolation_cookie;
-        }
-
-        co_await negotiate_protocol(std::move(features));
-
-        _propagate_timeout = !is_stream();
-        set_negotiated();
-        while (!_connected->read_buf.eof() && !_error) {
-            if (is_stream()) {
-                co_await handle_stream_frame();
-                continue;
-            }
-            auto&& [msg_id, ht, data] = co_await read_response_frame_compressed(_connected->read_buf);
-            auto it = _outstanding.find(std::abs(msg_id));
-            if (!data) {
-                _error = true;
-            } else if (it != _outstanding.end()) {
-                auto handler = std::move(it->second);
-                _outstanding.erase(it);
-                (*handler)(*this, msg_id, std::move(data.value()));
-                if (ht) {
-                    _stats.delay_samples++;
-                    _stats.delay_total += (rpc_clock_type::now() - handler->start) - std::chrono::microseconds(*ht);
-                }
-            } else if (msg_id < 0) {
-                try {
-                    std::rethrow_exception(unmarshal_exception(data.value()));
-                } catch(const unknown_verb_error& ex) {
-                    // if this is unknown verb exception with unknown id ignore it
-                    // can happen if unknown verb was used by no_wait client
-                    get_logger()(peer_address(), format("unknown verb exception {:d} ignored", ex.type));
-                } catch(...) {
-                    // We've got error response but handler is no longer waiting, could be timed out.
-                    log_exception(*this, log_level::info, "ignoring error response", std::current_exception());
-                }
-            } else {
-                // we get a reply for a message id not in _outstanding
-                // this can happened if the message id is timed out already
-                get_logger()(peer_address(), log_level::debug, "got a reply for an expired message id");
-            }
-        }
+        co_await process_client_connection();
     } catch (...) {
         ep = std::current_exception();
-        if (_connected) {
+        auto expected_close = _error && _transport && _transport->is_closed_exception(ep);
+        if (expected_close) {
+            ep = nullptr;
+        } else if (connected()) {
             if (is_stream()) {
                 log_exception(*this, log_level::error, "client stream connection dropped", ep);
             } else {
@@ -1046,6 +1439,58 @@ future<> client::loop(client_options ops, const socket_address& addr, const sock
     _error = true;
     future<> f = co_await coroutine::as_future(stop_send_loop(ep));
     f.ignore_ready_future();
+    abort_all_multiplexed_requests();
+    co_await _response_gate.close();
+    _active_multiplexed_requests.clear();
+    _outstanding.clear();
+    if (is_stream()) {
+        deregister_this_stream();
+    } else {
+        abort_all_streams();
+    }
+    if (_compressor) {
+        co_await _compressor->close();
+    }
+    _stopped.set_value();
+}
+
+future<> client::loop(client_options ops, const socket_address& addr, const socket_address& local) {
+    std::exception_ptr ep;
+    try {
+        connected_socket fd = co_await _socket.connect(addr, local);
+        fd.set_nodelay(ops.tcp_nodelay);
+        if (ops.keepalive) {
+            fd.set_keepalive(true);
+            fd.set_keepalive_parameters(ops.keepalive.value());
+        }
+        set_socket(std::move(fd));
+
+        co_await process_client_connection();
+    } catch (...) {
+        ep = std::current_exception();
+        if (connected()) {
+            if (is_stream()) {
+                log_exception(*this, log_level::error, "client stream connection dropped", ep);
+            } else {
+                log_exception(*this, log_level::error, "client connection dropped", ep);
+            }
+        } else {
+            if (is_stream()) {
+                log_exception(*this, log_level::debug, "stream fail to connect", ep);
+            } else {
+                log_exception(*this, log_level::debug, "fail to connect", ep);
+            }
+        }
+    }
+    if (is_stream() && (ep || _error)) {
+        _stream_queue.abort(std::make_exception_ptr(stream_closed()));
+    }
+    _error = true;
+    future<> f = co_await coroutine::as_future(stop_send_loop(ep));
+    f.ignore_ready_future();
+    abort_all_multiplexed_requests();
+    co_await _response_gate.close();
+    _active_multiplexed_requests.clear();
     _outstanding.clear();
     if (is_stream()) {
         deregister_this_stream();
@@ -1166,7 +1611,7 @@ server::connection::negotiate(feature_map requested) {
 
 future<>
 server::connection::negotiate_protocol() {
-    return receive_negotiation_frame(*this, _connected->read_buf).then([this] (feature_map requested_features) {
+    return receive_negotiation_frame(*this, transport_input()).then([this] (feature_map requested_features) {
         return negotiate(std::move(requested_features)).then([this] (feature_map returned_features) {
             return send_negotiation_frame(std::move(returned_features));
         });
@@ -1182,8 +1627,88 @@ server::connection::read_request_frame_compressed(input_stream<char>& in) {
     }
 }
 
+future<internal::incoming_request>
+server::connection::receive_request_frame(input_stream<char>& in) {
+    auto [expire, type, msg_id, data] = co_await read_request_frame_compressed(in);
+    co_return internal::incoming_request{
+        .expire = expire,
+        .type = type,
+        .msg_id = msg_id,
+        .data = std::move(data),
+        .reply = make_reply_handle(),
+    };
+}
+
+future<internal::incoming_request>
+server::connection::receive_quic_request_frame(input_stream<char>& in) {
+    request_frame::return_type frame;
+    if (_timeout_negotiated) {
+        if (_compressor) {
+            frame = co_await read_quic_request_frame_compressed<request_frame_with_timeout>(*this, _compressor, in);
+        } else {
+            frame = co_await read_quic_request_frame_uncompressed<request_frame_with_timeout>(*this, in);
+        }
+    } else {
+        if (_compressor) {
+            frame = co_await read_quic_request_frame_compressed<request_frame>(*this, _compressor, in);
+        } else {
+            frame = co_await read_quic_request_frame_uncompressed<request_frame>(*this, in);
+        }
+    }
+
+    auto [expire, type, msg_id, data] = std::move(frame);
+    co_return internal::incoming_request{
+        .expire = expire,
+        .type = type,
+        .msg_id = msg_id,
+        .data = std::move(data),
+        .reply = make_reply_handle(),
+    };
+}
+
+future<internal::incoming_request>
+server::connection::receive_multiplexed_request() {
+    while (true) {
+        auto stream = co_await _transport->accept_request_stream();
+        auto request = co_await receive_quic_request_frame(stream->input());
+        auto stream_state = make_lw_shared<std::unique_ptr<transport::stream>>(std::move(stream));
+        if (!request.data) {
+            co_await (*stream_state)->close_output();
+            continue;
+        }
+        auto drain_state = stream_state;
+        (void)(*drain_state)->drain_input().finally([drain_state] {}).handle_exception([] (std::exception_ptr) {});
+
+        auto rpc_owner = shared_from_this();
+        request.reply = internal::reply_handle([stream_state, rpc_owner] (snd_buf&& data, std::optional<rpc_clock_type::time_point> timeout) mutable {
+            if (timeout && *timeout <= rpc_clock_type::now()) {
+                return (*stream_state)->close_output();
+            }
+            return write_snd_buf((*stream_state)->output(), rpc_owner->compress(std::move(data))).handle_exception([stream_state] (std::exception_ptr ep) {
+                if ((*stream_state)->is_closed_exception(ep)) {
+                    return make_ready_future<>();
+                }
+                return make_exception_future<>(ep);
+            }).finally([stream_state] {
+                return (*stream_state)->close_output();
+            });
+        }, [stream_state] () mutable {
+            return (*stream_state)->close_output();
+        });
+        co_return request;
+    }
+}
+
+future<internal::incoming_request>
+server::connection::receive_request() {
+    if (_transport && _transport->supports_multiplexed_requests()) {
+        return receive_multiplexed_request();
+    }
+    return receive_request_frame(transport_input());
+}
+
 future<>
-server::connection::respond(int64_t msg_id, snd_buf&& data, std::optional<rpc_clock_type::time_point> timeout, std::optional<rpc_clock_type::duration> handler_duration) {
+server::connection::respond(internal::reply_handle reply, int64_t msg_id, snd_buf&& data, std::optional<rpc_clock_type::time_point> timeout, std::optional<rpc_clock_type::duration> handler_duration) {
     if (_handler_duration_negotiated) {
         response_frame_with_handler_time::encode_header(msg_id, handler_duration, data);
     } else {
@@ -1191,11 +1716,19 @@ server::connection::respond(int64_t msg_id, snd_buf&& data, std::optional<rpc_cl
         data.size -= sizeof(uint32_t);
         response_frame::encode_header(msg_id, data);
     }
-    return send(std::move(data), timeout);
+    if (!reply.send) {
+        return make_exception_future<>(closed_error());
+    }
+    return reply.send(std::move(data), timeout);
 }
 
-future<> server::connection::send_unknown_verb_reply(std::optional<rpc_clock_type::time_point> timeout, int64_t msg_id, uint64_t type) {
-    return wait_for_resources(28, timeout).then([this, timeout, msg_id, type] (auto permit) {
+future<>
+server::connection::respond(int64_t msg_id, snd_buf&& data, std::optional<rpc_clock_type::time_point> timeout, std::optional<rpc_clock_type::duration> handler_duration) {
+    return respond(make_reply_handle(), msg_id, std::move(data), timeout, handler_duration);
+}
+
+future<> server::connection::send_unknown_verb_reply(internal::reply_handle reply, std::optional<rpc_clock_type::time_point> timeout, int64_t msg_id, uint64_t type) {
+    return wait_for_resources(28, timeout).then([this, timeout, msg_id, type, reply = std::move(reply)] (auto permit) mutable {
         // send unknown_verb exception back
         constexpr size_t unknown_verb_message_size = response_frame_headroom + 2 * sizeof(uint32_t) + sizeof(uint64_t);
         snd_buf data(unknown_verb_message_size);
@@ -1207,12 +1740,40 @@ future<> server::connection::send_unknown_verb_reply(std::optional<rpc_clock_typ
         try {
             // Send asynchronously.
             // This is safe since connection::stop() will wait for background work.
-            (void)with_gate(get_server()._reply_gate, [this, timeout, msg_id, data = std::move(data), permit = std::move(permit)] () mutable {
+            (void)with_gate(get_server()._reply_gate, [this, timeout, msg_id, data = std::move(data), permit = std::move(permit), reply = std::move(reply)] () mutable {
                 // workaround for https://gcc.gnu.org/bugzilla/show_bug.cgi?id=83268
                 auto c = shared_from_this();
-                return respond(-msg_id, std::move(data), timeout, std::nullopt).then([c = std::move(c), permit = std::move(permit)] {});
+                return respond(std::move(reply), -msg_id, std::move(data), timeout, std::nullopt).then([c = std::move(c), permit = std::move(permit)] {});
             });
         } catch(gate_closed_exception&) {/* ignore */}
+    });
+}
+
+future<> server::connection::process_request(internal::incoming_request request) {
+    if (!request.data) {
+        _error = true;
+        co_return;
+    }
+
+    std::optional<rpc_clock_type::time_point> timeout;
+    if (request.expire && *request.expire) {
+        timeout = relative_timeout_to_absolute(std::chrono::milliseconds(*request.expire));
+    }
+    auto h = get_server()._proto.get_handler(request.type);
+    if (!h) {
+        co_await send_unknown_verb_reply(std::move(request.reply), timeout, request.msg_id, request.type);
+        co_return;
+    }
+
+    // If the new method of per-connection scheduling group was used, honor it.
+    // Otherwise, use the old per-handler scheduling group.
+    auto sg = _isolation_config ? _isolation_config->sched_group : h->handler.sg;
+    if (sg == current_scheduling_group()) {
+        co_await h->handler.func(shared_from_this(), timeout, request.msg_id, std::move(request.data.value()), std::move(request.reply), std::move(h->holder));
+        co_return;
+    }
+    co_await with_scheduling_group(sg, [this, timeout, msg_id = request.msg_id, &h = h->handler, data = std::move(request.data.value()), reply = std::move(request.reply), guard = std::move(h->holder)] () mutable {
+        return h.func(shared_from_this(), timeout, msg_id, std::move(data), std::move(reply), std::move(guard));
     });
 }
 
@@ -1225,44 +1786,38 @@ future<> server::connection::process() {
         auto sg = _isolation_config ? _isolation_config->sched_group : current_scheduling_group();
         co_await coroutine::switch_to(sg);
         set_negotiated();
-        while (!_connected->read_buf.eof() && !_error) {
+        while (!transport_input().eof() && !_error) {
             if (is_stream()) {
                 co_await handle_stream_frame();
                 continue;
             }
-            auto [expire, type, msg_id, data] = co_await read_request_frame_compressed(_connected->read_buf);
-            if (!data) {
-                _error = true;
-                continue;
-            } else {
-                std::optional<rpc_clock_type::time_point> timeout;
-                if (expire && *expire) {
-                    timeout = relative_timeout_to_absolute(std::chrono::milliseconds(*expire));
-                }
-                auto h = get_server()._proto.get_handler(type);
-                if (!h) {
-                    co_await send_unknown_verb_reply(timeout, msg_id, type);
-                    continue;
-                }
-
-                // If the new method of per-connection scheduling group was used, honor it.
-                // Otherwise, use the old per-handler scheduling group.
-                auto sg = _isolation_config ? _isolation_config->sched_group : h->handler.sg;
-                if (sg == current_scheduling_group()) {
-                    co_await h->handler.func(shared_from_this(), timeout, msg_id, std::move(data.value()), std::move(h->holder));
-                    continue;
-                }
-                co_await with_scheduling_group(sg, [this, timeout, msg_id, &h = h->handler, data = std::move(data.value()), guard = std::move(h->holder)] () mutable {
-                    return h.func(shared_from_this(), timeout, msg_id, std::move(data), std::move(guard));
+            auto request = co_await receive_request();
+            if (_transport && _transport->supports_multiplexed_requests()) {
+                auto error_conn = shared_from_this();
+                (void)try_with_gate(_request_gate, [this, conn = shared_from_this(), request = std::move(request)] () mutable {
+                    return process_request(std::move(request)).finally([conn = std::move(conn)] {});
+                }).handle_exception([this, error_conn = std::move(error_conn)] (std::exception_ptr handler_ep) {
+                    if (!_transport || !_transport->is_closed_exception(handler_ep)) {
+                        _error = true;
+                        shutdown_transport_input();
+                        log_exception(*this, log_level::error, "server request handler failed", handler_ep);
+                    }
                 });
+                continue;
             }
+            co_await process_request(std::move(request));
         }
     } catch (...) {
         ep = std::current_exception();
-        log_exception(*this, log_level::error,
-            format("server{} connection dropped", is_stream() ? " stream" : "").c_str(), ep);
+        if (_transport && _transport->is_closed_exception(ep)) {
+            ep = nullptr;
+        } else {
+            log_exception(*this, log_level::error,
+                format("server{} connection dropped", is_stream() ? " stream" : "").c_str(), ep);
+        }
     }
-    _connected->fd.shutdown_input();
+    co_await _request_gate.close();
+    shutdown_transport_input();
     if (is_stream() && (ep || _error)) {
         _stream_queue.abort(std::make_exception_ptr(stream_closed()));
     }
@@ -1284,6 +1839,12 @@ future<> server::connection::process() {
 server::connection::connection(server& s, connected_socket&& fd, socket_address&& addr, const logger& l, void* serializer, connection_id id)
         : rpc::connection(std::move(fd), l, serializer, id)
         , _info{.addr{std::move(addr)}, .server{s}, .conn_id{id}} {
+}
+
+server::connection::connection(server& s, std::unique_ptr<transport> transport, socket_address&& addr, const logger& l, void* serializer, connection_id id)
+        : rpc::connection(l, serializer, id)
+        , _info{.addr{std::move(addr)}, .server{s}, .conn_id{id}} {
+    set_transport(std::move(transport));
 }
 
 future<> server::connection::deregister_this_stream() {
@@ -1314,16 +1875,84 @@ future<> server::connection::abort_all_streams() {
 
 thread_local std::unordered_map<streaming_domain_type, server*> server::_servers;
 
+namespace {
+
+class connected_socket_server_acceptor final : public server::acceptor {
+    server_socket _ss;
+    bool _tcp_nodelay = false;
+
+public:
+    connected_socket_server_acceptor(server_socket ss, bool tcp_nodelay)
+            : _ss(std::move(ss))
+            , _tcp_nodelay(tcp_nodelay) {
+    }
+
+    future<server::accepted_connection> accept() override {
+        auto ar = co_await _ss.accept();
+        ar.connection.set_nodelay(_tcp_nodelay);
+        co_return server::accepted_connection{
+            .remote_address = std::move(ar.remote_address),
+            .transport = std::make_unique<connected_socket_transport>(std::move(ar.connection)),
+        };
+    }
+
+    future<> stop() override {
+        _ss.abort_accept();
+        return make_ready_future<>();
+    }
+};
+
+std::unique_ptr<server::acceptor>
+make_connected_socket_server_acceptor(server_socket ss, bool tcp_nodelay) {
+    return std::make_unique<connected_socket_server_acceptor>(std::move(ss), tcp_nodelay);
+}
+
+template <typename Acceptor, typename Handler, typename OnStop>
+void run_accept_loop(Acceptor& acceptor, Handler handler, OnStop on_stop) {
+    // Run asynchronously in background.
+    // Communicate result via _accept_stopped.
+    // The caller has to call server::stop() to synchronize.
+    (void)keep_doing([&acceptor, handler = std::move(handler)] () mutable {
+        return acceptor.accept().then([handler] (auto accepted) mutable {
+            return handler(std::move(accepted));
+        });
+    }).then_wrapped([on_stop = std::move(on_stop)] (future<>&& f) mutable {
+        try {
+            f.get();
+            SEASTAR_ASSERT(false);
+        } catch (...) {
+            on_stop();
+        }
+    });
+}
+
+}
+
 server::server(protocol_base* proto, const socket_address& addr, resource_limits limits)
-        : server(proto, seastar::listen(addr, listen_options{true}), limits, server_options{})
+        : server(proto, server_options{}, addr, limits)
 {}
 
 server::server(protocol_base* proto, server_options opts, const socket_address& addr, resource_limits limits)
-        : server(proto, seastar::listen(addr, listen_options{true, opts.load_balancing_algorithm}), limits, opts)
+        : server(proto,
+                 opts,
+                 seastar::listen(addr, listen_options{true, opts.load_balancing_algorithm}),
+                 limits)
 {}
 
 server::server(protocol_base* proto, server_socket ss, resource_limits limits, server_options opts)
-        : _proto(*proto), _ss(std::move(ss)), _limits(limits), _resources_available(limits.max_memory), _options(opts)
+        : server(proto, make_connected_socket_server_acceptor(std::move(ss), opts.tcp_nodelay), limits, std::move(opts))
+{}
+
+server::server(protocol_base* proto, server_options opts, server_socket ss, resource_limits limits)
+        : server(proto, std::move(ss), limits, std::move(opts))
+{}
+
+server::server(protocol_base* proto, std::unique_ptr<acceptor> acceptor, resource_limits limits, server_options opts)
+        : _proto(*proto)
+        , _acceptor(std::move(acceptor))
+        , _limits(limits)
+        , _resources_available(limits.max_memory)
+        , _options(std::move(opts))
 {
     if (_options.streaming_domain) {
         if (_servers.find(*_options.streaming_domain) != _servers.end()) {
@@ -1334,57 +1963,48 @@ server::server(protocol_base* proto, server_socket ss, resource_limits limits, s
     accept();
 }
 
-server::server(protocol_base* proto, server_options opts, server_socket ss, resource_limits limits)
-        : server(proto, std::move(ss), limits, opts)
+server::server(protocol_base* proto, server_options opts, std::unique_ptr<acceptor> acceptor, resource_limits limits)
+        : server(proto, std::move(acceptor), limits, std::move(opts))
 {}
 
 void server::accept() {
-    // Run asynchronously in background.
-    // Communicate result via __ss_stopped.
-    // The caller has to call server::stop() to synchronize.
-    (void)keep_doing([this] () mutable {
-        return _ss.accept().then([this] (accept_result ar) mutable {
-            if (_options.filter_connection && !_options.filter_connection(ar.remote_address)) {
-                return;
-            }
-            auto fd = std::move(ar.connection);
-            auto addr = std::move(ar.remote_address);
-            fd.set_nodelay(_options.tcp_nodelay);
-            connection_id id = _options.streaming_domain
-                    ? connection_id::make_id(_next_client_id++, uint16_t(this_shard_id()))
-                    : connection_id::make_invalid_id(_next_client_id++);
-            auto conn = _proto.make_server_connection(*this, std::move(fd), std::move(addr), id);
-            auto r = _conns.emplace(id, conn);
-            SEASTAR_ASSERT(r.second);
-            // Process asynchronously in background.
-            (void)conn->process();
-        });
-    }).then_wrapped([this] (future<>&& f){
-        try {
-            f.get();
-            SEASTAR_ASSERT(false);
-        } catch (...) {
-            _ss_stopped.set_value();
+    run_accept_loop(*_acceptor, [this] (accepted_connection accepted) mutable -> future<> {
+        if (_shutdown) {
+            co_await accepted.transport->stop();
+            co_return;
         }
+        if (_options.filter_connection && !_options.filter_connection(accepted.remote_address)) {
+            co_await accepted.transport->stop();
+            co_return;
+        }
+
+        connection_id id = _options.streaming_domain
+                ? connection_id::make_id(_next_client_id++, uint16_t(this_shard_id()))
+                : connection_id::make_invalid_id(_next_client_id++);
+        auto conn = _proto.make_server_connection(*this, std::move(accepted.transport), std::move(accepted.remote_address), id);
+        auto r = _conns.emplace(id, conn);
+        SEASTAR_ASSERT(r.second);
+        (void)conn->process();
+        co_return;
+    }, [this] {
+        _accept_stopped.set_value();
     });
 }
 
 future<> server::shutdown() {
     if (_shutdown) {
-        return make_ready_future<>();
+        co_return;
     }
 
-    _ss.abort_accept();
+    _shutdown = true;
+    co_await _acceptor->stop().handle_exception([] (std::exception_ptr) {});
     _resources_available.broken();
     if (_options.streaming_domain) {
         _servers.erase(*_options.streaming_domain);
     }
-    return _ss_stopped.get_future().then([this] {
-        return parallel_for_each(_conns | boost::adaptors::map_values, [] (shared_ptr<connection> conn) {
-            return conn->stop();
-        });
-    }).finally([this] {
-        _shutdown = true;
+    co_await _accept_stopped.get_future();
+    co_await parallel_for_each(_conns | boost::adaptors::map_values, [] (shared_ptr<connection> conn) {
+        return conn->stop();
     });
 }
 

--- a/src/rpc/rpc_quic_transport.cc
+++ b/src/rpc/rpc_quic_transport.cc
@@ -1,0 +1,277 @@
+/*
+ * This file is open source software, licensed to you under the terms
+ * of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.  You may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <seastar/rpc/rpc_quic_transport.hh>
+
+namespace seastar::rpc {
+
+connected_socket_transport::connected_socket_transport(connected_socket fd) noexcept
+    : _fd(std::move(fd))
+    , _input(_fd.input())
+    , _output(_fd.output()) {
+}
+
+input_stream<char>& connected_socket_transport::input() {
+    return _input;
+}
+
+output_stream<char>& connected_socket_transport::output() {
+    return _output;
+}
+
+void connected_socket_transport::shutdown_input() {
+    _fd.shutdown_input();
+}
+
+void connected_socket_transport::shutdown_output() {
+    _fd.shutdown_output();
+}
+
+namespace experimental {
+
+namespace {
+
+class quic_server_acceptor final : public server::acceptor {
+    quic::experimental::quic_server _server;
+    quic::experimental::quic_server_config _config;
+    bool _started = false;
+
+public:
+    explicit quic_server_acceptor(quic::experimental::quic_server_config config)
+            : _config(std::move(config)) {
+    }
+
+    future<server::accepted_connection> accept() override {
+        if (!_started) {
+            co_await _server.start(std::move(_config));
+            _started = true;
+        }
+
+        auto session = co_await _server.accept();
+        auto addr = session.peer_address();
+        try {
+            auto control_stream = co_await session.accept_stream();
+            co_return server::accepted_connection{
+                .remote_address = std::move(addr),
+                .transport = std::make_unique<quic_server_transport>(std::move(session), std::move(control_stream)),
+            };
+        } catch (...) {
+            auto ep = std::current_exception();
+            (void)session.close().handle_exception([] (std::exception_ptr) {});
+            std::rethrow_exception(ep);
+        }
+    }
+
+    future<> stop() override {
+        co_await _server.stop();
+    }
+};
+
+bool is_quic_closed_exception(std::exception_ptr ep) noexcept {
+    try {
+        std::rethrow_exception(ep);
+    } catch (const quic::experimental::quic_error& ex) {
+        return ex.code() == quic::experimental::quic_error::closed;
+    } catch (...) {
+        return false;
+    }
+}
+
+future<> ignore_quic_closed_exception(std::exception_ptr ep) {
+    if (is_quic_closed_exception(ep)) {
+        return make_ready_future<>();
+    }
+    return make_exception_future<>(ep);
+}
+
+future<> abort_quic_stream(quic::experimental::stream& stream) {
+    co_await stream.reset().handle_exception([] (std::exception_ptr ep) {
+        return ignore_quic_closed_exception(ep);
+    });
+    co_await stream.stop_sending().handle_exception([] (std::exception_ptr ep) {
+        return ignore_quic_closed_exception(ep);
+    });
+}
+
+class quic_transport_stream final : public connection::transport::stream {
+    quic::experimental::stream _stream;
+    input_stream<char> _input;
+    output_stream<char> _output;
+    bool _output_closed = false;
+
+public:
+    explicit quic_transport_stream(quic::experimental::stream stream)
+            : _stream(std::move(stream))
+            , _input(_stream.input())
+            , _output(_stream.output()) {
+    }
+
+    input_stream<char>& input() override {
+        return _input;
+    }
+
+    output_stream<char>& output() override {
+        return _output;
+    }
+
+    future<> close_output() override {
+        if (_output_closed) {
+            return make_ready_future<>();
+        }
+        _output_closed = true;
+        return _output.close().handle_exception([] (std::exception_ptr ep) {
+            return ignore_quic_closed_exception(ep);
+        });
+    }
+
+    future<> stop_input() override {
+        return _stream.stop_sending().handle_exception([] (std::exception_ptr ep) {
+            return ignore_quic_closed_exception(ep);
+        });
+    }
+
+    future<> abort() override {
+        return abort_quic_stream(_stream);
+    }
+};
+
+} // anonymous namespace
+
+std::unique_ptr<server::acceptor> make_quic_server_acceptor(quic::experimental::quic_server_config config) {
+    return std::make_unique<quic_server_acceptor>(std::move(config));
+}
+
+quic_client_transport::quic_client_transport(
+        seastar::quic::experimental::quic_client client,
+        seastar::quic::experimental::connection conn,
+        seastar::quic::experimental::stream control_stream)
+        : _client(std::move(client))
+        , _conn(std::move(conn))
+        , _control_stream(std::move(control_stream))
+        , _control_input(_control_stream.input())
+        , _control_output(_control_stream.output()) {
+}
+
+quic_client_transport::quic_client_transport(
+        seastar::quic::experimental::connection conn,
+        seastar::quic::experimental::stream control_stream)
+        : _conn(std::move(conn))
+        , _control_stream(std::move(control_stream))
+        , _control_input(_control_stream.input())
+        , _control_output(_control_stream.output()) {
+}
+
+input_stream<char>& quic_client_transport::input() {
+    return _control_input;
+}
+
+output_stream<char>& quic_client_transport::output() {
+    return _control_output;
+}
+
+void quic_client_transport::shutdown_input() {
+    (void)_control_stream.stop_sending().handle_exception([] (std::exception_ptr) {});
+}
+
+void quic_client_transport::shutdown_output() {
+    (void)_control_output.close().handle_exception([] (std::exception_ptr) {});
+}
+
+bool quic_client_transport::supports_multiplexed_requests() const {
+    return true;
+}
+
+future<> quic_client_transport::stop() {
+    try {
+        co_await _control_stream.stop_sending();
+    } catch (...) {
+    }
+    try {
+        co_await _control_output.close();
+    } catch (...) {
+    }
+    if (_client) {
+        try {
+            co_await _client->stop();
+        } catch (...) {
+        }
+    } else {
+        try {
+            co_await _conn.close();
+        } catch (...) {
+        }
+    }
+}
+
+future<std::unique_ptr<connection::transport::stream>> quic_client_transport::open_request_stream() {
+    auto stream = co_await _conn.open_stream();
+    co_return std::make_unique<quic_transport_stream>(std::move(stream));
+}
+
+quic_server_transport::quic_server_transport(
+        seastar::quic::experimental::connection conn,
+        seastar::quic::experimental::stream control_stream)
+        : _conn(std::move(conn))
+        , _control_stream(std::move(control_stream))
+        , _control_input(_control_stream.input())
+        , _control_output(_control_stream.output()) {
+}
+
+input_stream<char>& quic_server_transport::input() {
+    return _control_input;
+}
+
+output_stream<char>& quic_server_transport::output() {
+    return _control_output;
+}
+
+void quic_server_transport::shutdown_input() {
+    (void)_control_stream.stop_sending().handle_exception([] (std::exception_ptr) {});
+}
+
+void quic_server_transport::shutdown_output() {
+    (void)_control_output.close().handle_exception([] (std::exception_ptr) {});
+}
+
+future<> quic_server_transport::stop() {
+    try {
+        co_await _control_stream.stop_sending();
+    } catch (...) {
+    }
+    try {
+        co_await _control_output.close();
+    } catch (...) {
+    }
+    try {
+        co_await _conn.close();
+    } catch (...) {
+    }
+}
+
+bool quic_server_transport::supports_multiplexed_requests() const {
+    return true;
+}
+
+future<std::unique_ptr<connection::transport::stream>> quic_server_transport::accept_request_stream() {
+    auto stream = co_await _conn.accept_stream();
+    co_return std::make_unique<quic_transport_stream>(std::move(stream));
+}
+
+} // namespace experimental
+
+} // namespace seastar::rpc

--- a/src/rpc/rpc_quic_transport.cc
+++ b/src/rpc/rpc_quic_transport.cc
@@ -18,31 +18,7 @@
 
 #include <seastar/rpc/rpc_quic_transport.hh>
 
-namespace seastar::rpc {
-
-connected_socket_transport::connected_socket_transport(connected_socket fd) noexcept
-    : _fd(std::move(fd))
-    , _input(_fd.input())
-    , _output(_fd.output()) {
-}
-
-input_stream<char>& connected_socket_transport::input() {
-    return _input;
-}
-
-output_stream<char>& connected_socket_transport::output() {
-    return _output;
-}
-
-void connected_socket_transport::shutdown_input() {
-    _fd.shutdown_input();
-}
-
-void connected_socket_transport::shutdown_output() {
-    _fd.shutdown_output();
-}
-
-namespace experimental {
+namespace seastar::rpc::experimental {
 
 namespace {
 
@@ -108,6 +84,16 @@ future<> abort_quic_stream(quic::experimental::stream& stream) {
     });
 }
 
+future<> drain_quic_stream_fin(input_stream<char>& in) {
+    return repeat([&in] {
+        return in.read().then([] (temporary_buffer<char> data) {
+            return data.empty() ? stop_iteration::yes : stop_iteration::no;
+        });
+    }).handle_exception([] (std::exception_ptr ep) {
+        return ignore_quic_closed_exception(ep);
+    });
+}
+
 class quic_transport_stream final : public connection::transport::stream {
     quic::experimental::stream _stream;
     input_stream<char> _input;
@@ -147,6 +133,14 @@ public:
 
     future<> abort() override {
         return abort_quic_stream(_stream);
+    }
+
+    bool is_closed_exception(std::exception_ptr ep) const noexcept override {
+        return is_quic_closed_exception(ep);
+    }
+
+    future<> drain_input() override {
+        return drain_quic_stream_fin(_input);
     }
 };
 
@@ -194,6 +188,10 @@ void quic_client_transport::shutdown_output() {
 
 bool quic_client_transport::supports_multiplexed_requests() const {
     return true;
+}
+
+bool quic_client_transport::is_closed_exception(std::exception_ptr ep) const noexcept {
+    return is_quic_closed_exception(ep);
 }
 
 future<> quic_client_transport::stop() {
@@ -267,11 +265,13 @@ bool quic_server_transport::supports_multiplexed_requests() const {
     return true;
 }
 
+bool quic_server_transport::is_closed_exception(std::exception_ptr ep) const noexcept {
+    return is_quic_closed_exception(ep);
+}
+
 future<std::unique_ptr<connection::transport::stream>> quic_server_transport::accept_request_stream() {
     auto stream = co_await _conn.accept_stream();
     co_return std::make_unique<quic_transport_stream>(std::move(stream));
 }
 
-} // namespace experimental
-
-} // namespace seastar::rpc
+} // namespace seastar::rpc::experimental

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -494,6 +494,13 @@ seastar_add_test (rpc_tcp
     rpc_test_body_tcp.inc.hh
     rpc_tcp_test.cc)
 
+seastar_add_test (rpc_quic
+  SOURCES
+    rpc_test_body.inc.hh
+    rpc_quic_test.cc
+  LIBRARIES Boost::filesystem
+  DEPENDS testcrt)
+
 seastar_add_test (semaphore
   SOURCES
     semaphore_test.cc

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -488,6 +488,12 @@ seastar_add_test (rpc
     loopback_socket.hh
     rpc_test.cc)
 
+seastar_add_test (rpc_tcp
+  SOURCES
+    loopback_socket.hh
+    rpc_test_body_tcp.inc.hh
+    rpc_tcp_test.cc)
+
 seastar_add_test (semaphore
   SOURCES
     semaphore_test.cc

--- a/tests/unit/README.rpc-tests.md
+++ b/tests/unit/README.rpc-tests.md
@@ -1,0 +1,25 @@
+# RPC unit tests (TCP loopback & QUIC)
+
+Two parallel suites run the **same** `seastar::rpc::protocol` test cases over two
+transports, differing only in how client/server are wired:
+
+| Suite      | Transport           | Test TU            | Shared body                | ctest name              |
+|------------|---------------------|--------------------|----------------------------|-------------------------|
+| `rpc_tcp`  | TCP loopback        | `rpc_tcp_test.cc`  | `rpc_test_body_tcp.inc.hh` | `Seastar.unit.rpc_tcp`  |
+| `rpc_quic` | QUIC (ngtcp2 + TLS) | `rpc_quic_test.cc` | `rpc_test_body.inc.hh`     | `Seastar.unit.rpc_quic` |
+
+`rpc_tcp` drives the in-process `loopback_socket`, so it exercises the protocol
+logic with no real network/TLS. `rpc_quic` runs the same cases end-to-end against
+a real QUIC server. Both failing points to the protocol; only `rpc_quic` failing
+points to the QUIC transport. (Distinct from the upstream `rpc` suite,
+`rpc_test.cc`, which covers the full sharded stack.)
+
+## Run
+
+```sh
+ninja -C build/dev test_unit_rpc_tcp test_unit_rpc_quic
+ctest --test-dir build/dev -R 'Seastar.unit.rpc_(tcp|quic)' --output-on-failure
+```
+
+`rpc_quic` additionally links `Boost::filesystem` and `DEPENDS testcrt` (builds
+the test certs next to the executable); it listens on `127.0.0.1:52000+`.

--- a/tests/unit/rpc_quic_test.cc
+++ b/tests/unit/rpc_quic_test.cc
@@ -1,0 +1,11 @@
+/*
+ * Unit tests for RPC over QUIC.
+ *
+ * Every test drives a real QUIC transport (TLS handshake + ngtcp2),
+ * using the build-time `testcrt` certificate placed next to the test
+ * executable.
+ */
+
+#include <seastar/rpc/rpc.hh>
+#include <seastar/rpc/rpc_quic_transport.hh>
+#include "rpc_test_body.inc.hh"

--- a/tests/unit/rpc_tcp_test.cc
+++ b/tests/unit/rpc_tcp_test.cc
@@ -1,0 +1,9 @@
+/*
+ * Unit tests for the RPC implementation driving the TCP loopback path, so the
+ * protocol/state-machine logic is exercised independently of any QUIC
+ * transport. This is the baseline that predates the QUIC-transport variant
+ * (see rpc_quic_test.cc).
+ */
+
+#include <seastar/rpc/rpc.hh>
+#include "rpc_test_body_tcp.inc.hh"

--- a/tests/unit/rpc_test_body.inc.hh
+++ b/tests/unit/rpc_test_body.inc.hh
@@ -1,0 +1,702 @@
+/*
+ * This file is open source software, licensed to you under the terms
+ * of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.  You may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Shared body for the QUIC-RPC unit tests.
+ *
+ * The including TU must already have included <seastar/rpc/rpc.hh>.
+ *
+ * Each test spins up a real QUIC server (TLS via the build-time `testcrt`
+ * certificate target), creates one or more `protocol::client`s via
+ * `protocol::make_quic_client(...)`, and tears everything down on exit.
+ *
+ * Listen address: 127.0.0.1:<unique-port>, advanced per-test by a static
+ * counter so back-to-back tests in the same binary don't trip TIME_WAIT.
+ */
+
+#include <atomic>
+#include <ranges>
+#include <boost/dll/runtime_symbol_info.hpp>
+
+#include <seastar/rpc/rpc_types.hh>
+#include <seastar/rpc/lz4_compressor.hh>
+#include <seastar/rpc/multi_algo_compressor_factory.hh>
+#include <seastar/quic/quic_client.hh>
+#include <seastar/quic/quic_server.hh>
+#include <seastar/core/scheduling.hh>
+#include <seastar/testing/test_case.hh>
+#include <seastar/testing/thread_test_case.hh>
+#include <seastar/core/sleep.hh>
+#include <seastar/core/thread.hh>
+#include <seastar/core/loop.hh>
+#include <seastar/core/coroutine.hh>
+#include <seastar/net/api.hh>
+#include <seastar/net/socket_defs.hh>
+#include <seastar/util/closeable.hh>
+#include <seastar/util/defer.hh>
+#include <seastar/util/log.hh>
+
+using namespace seastar;
+
+// ---------- minimal serializer (int / sstring) ----------
+
+struct serializer {};
+
+template <typename T, typename Output>
+inline void write_arith(Output& out, T v) {
+    out.write(reinterpret_cast<const char*>(&v), sizeof(T));
+}
+
+template <typename T, typename Input>
+inline T read_arith(Input& in) {
+    T v;
+    in.read(reinterpret_cast<char*>(&v), sizeof(T));
+    return v;
+}
+
+template <typename Output> inline void write(serializer, Output& o, int32_t v) { write_arith(o, v); }
+template <typename Output> inline void write(serializer, Output& o, uint32_t v) { write_arith(o, v); }
+template <typename Output> inline void write(serializer, Output& o, int64_t v) { write_arith(o, v); }
+template <typename Output> inline void write(serializer, Output& o, uint64_t v) { write_arith(o, v); }
+template <typename Input> inline int32_t  read(serializer, Input& i, rpc::type<int32_t>)  { return read_arith<int32_t>(i); }
+template <typename Input> inline uint32_t read(serializer, Input& i, rpc::type<uint32_t>) { return read_arith<uint32_t>(i); }
+template <typename Input> inline int64_t  read(serializer, Input& i, rpc::type<int64_t>)  { return read_arith<int64_t>(i); }
+template <typename Input> inline uint64_t read(serializer, Input& i, rpc::type<uint64_t>) { return read_arith<uint64_t>(i); }
+
+template <typename Output>
+inline void write(serializer, Output& o, const sstring& v) {
+    write_arith(o, uint32_t(v.size()));
+    o.write(v.c_str(), v.size());
+}
+template <typename Input>
+inline sstring read(serializer, Input& in, rpc::type<sstring>) {
+    auto sz = read_arith<uint32_t>(in);
+    sstring s = uninitialized_string(sz);
+    in.read(s.data(), sz);
+    return s;
+}
+
+using test_proto = rpc::protocol<serializer>;
+using test_client_ptr = std::unique_ptr<test_proto::client>;
+
+// ---------- QUIC test wiring ----------
+
+// Build-time-installed `testcrt` lands cert files next to the executable.
+inline std::string certfile(const std::string& name) {
+    return (boost::dll::program_location().parent_path() / name).string();
+}
+
+// Per-process counter for picking a fresh UDP port for each rpc_env.
+// Starts in the 49152-65535 ephemeral range; tests in one binary are
+// sequential, so a static counter avoids bind clashes.
+inline uint16_t next_quic_port() {
+    static std::atomic<uint16_t> counter{52000};
+    return counter.fetch_add(1, std::memory_order_relaxed);
+}
+
+inline void apply_test_quic_flow_limits(quic::experimental::connection_options& opts) {
+    opts.transport.initial_max_stream_data_bidi_local  = 4 * 1024 * 1024;
+    opts.transport.initial_max_stream_data_bidi_remote = 4 * 1024 * 1024;
+    opts.transport.initial_max_data                    = 64 * 1024 * 1024;
+    opts.transport.initial_max_streams_bidi            = 512;
+}
+
+// Build a fully-populated quic_server_config for tests.
+inline quic::experimental::quic_server_config make_test_quic_server_config(const socket_address& listen) {
+    quic::experimental::quic_server_config scfg;
+    scfg.listen_address = listen;
+    scfg.crt_file = certfile("test.crt");
+    scfg.key_file = certfile("test.key");
+    scfg.alpns = {sstring("seastar-rpc")};
+    apply_test_quic_flow_limits(scfg.session_options);
+    return scfg;
+}
+
+struct rpc_env {
+    socket_address listen_addr;
+    test_proto proto;
+    // New API on this branch: the server takes a quic_server_config directly;
+    // internally it wires up make_quic_server_acceptor.
+    test_proto::server server;
+    std::vector<int> handlers;
+
+    rpc_env(rpc::resource_limits rl, rpc::server_options so)
+        : listen_addr(socket_address(ipv4_addr("127.0.0.1", next_quic_port())))
+        , proto(serializer{})
+        , server(proto, std::move(so), make_test_quic_server_config(listen_addr), std::move(rl))
+    {}
+
+    ~rpc_env() = default;
+
+    // The new server constructor brings up the QUIC listener; nothing extra
+    // to do here. Kept for source compatibility with the old API.
+    void start() {}
+
+    // Build a QUIC-backed client connected to this server.
+    test_client_ptr make_client(rpc::client_options co = {}) {
+        quic::experimental::quic_client_config ccfg;
+        ccfg.remote_address = listen_addr;
+        ccfg.server_name = "test.scylladb.org";          // matches CN in testcrt
+        ccfg.ca_file = certfile("catest.pem");
+        ccfg.alpns = {sstring("seastar-rpc")};
+        apply_test_quic_flow_limits(ccfg.session_options);
+        return proto.make_quic_client(std::move(co), std::move(ccfg)).get();
+    }
+
+    template <typename Func>
+    void register_handler(int t, Func&& f) {
+        proto.register_handler(t, std::forward<Func>(f));
+        handlers.push_back(t);
+    }
+
+    template <typename Func>
+    void register_handler(int t, scheduling_group sg, Func&& f) {
+        proto.register_handler(t, sg, std::forward<Func>(f));
+        handlers.push_back(t);
+    }
+
+    future<> stop() {
+        std::vector<int> hs = std::move(handlers);
+        return parallel_for_each(hs, [this] (int t) {
+            return proto.unregister_handler(t);
+        }).finally([this] {
+            return server.stop();
+        });
+    }
+};
+
+// Helper that owns env + (optionally) a client and tears down in the right order.
+template <typename Body>
+future<> with_env(Body&& body, rpc::resource_limits rl = {}, rpc::server_options so = {}) {
+    return seastar::async([body = std::forward<Body>(body), rl = std::move(rl), so = std::move(so)] () mutable {
+        auto env = std::make_unique<rpc_env>(std::move(rl), std::move(so));
+        env->start();
+        std::exception_ptr ep;
+        try {
+            body(*env);
+        } catch (...) {
+            ep = std::current_exception();
+        }
+        env->stop().get();
+        if (ep) { std::rethrow_exception(ep); }
+    });
+}
+
+// ============================================================
+// Tests
+// ============================================================
+
+SEASTAR_TEST_CASE(test_basic_call) {
+    return with_env([] (rpc_env& env) {
+        env.register_handler(1, [] (int a, int b) {
+            return make_ready_future<int>(a + b);
+        });
+        auto c_h = env.make_client(); auto& c = *c_h;
+        auto sum = env.proto.make_client<int (int, int)>(1);
+        BOOST_REQUIRE_EQUAL(sum(c, 2, 3).get(), 5);
+        BOOST_REQUIRE_EQUAL(sum(c, -7, 7).get(), 0);
+        c.stop().get();
+    });
+}
+
+SEASTAR_TEST_CASE(test_void_return) {
+    return with_env([] (rpc_env& env) {
+        bool called = false;
+        env.register_handler(2, [&called] (int x) {
+            called = (x == 42);
+            return make_ready_future<>();
+        });
+        auto c_h = env.make_client(); auto& c = *c_h;
+        auto call = env.proto.make_client<void (int)>(2);
+        call(c, 42).get();
+        BOOST_REQUIRE(called);
+        c.stop().get();
+    });
+}
+
+SEASTAR_TEST_CASE(test_string_payload) {
+    return with_env([] (rpc_env& env) {
+        env.register_handler(3, [] (sstring s) {
+            return make_ready_future<sstring>(s + sstring("!"));
+        });
+        auto c_h = env.make_client(); auto& c = *c_h;
+        auto call = env.proto.make_client<sstring (sstring)>(3);
+        BOOST_REQUIRE_EQUAL(call(c, sstring("hi")).get(), sstring("hi!"));
+        c.stop().get();
+    });
+}
+
+SEASTAR_TEST_CASE(test_remote_verb_throws) {
+    return with_env([] (rpc_env& env) {
+        env.register_handler(4, [] () -> future<int> {
+            throw std::runtime_error("boom");
+        });
+        auto c_h = env.make_client(); auto& c = *c_h;
+        auto call = env.proto.make_client<int ()>(4);
+        BOOST_REQUIRE_THROW(call(c).get(), rpc::remote_verb_error);
+        c.stop().get();
+    });
+}
+
+SEASTAR_TEST_CASE(test_unknown_verb) {
+    return with_env([] (rpc_env& env) {
+        auto c_h = env.make_client(); auto& c = *c_h;
+        auto call = env.proto.make_client<int ()>(99);
+        BOOST_REQUIRE_THROW(call(c).get(), rpc::unknown_verb_error);
+        c.stop().get();
+    });
+}
+
+SEASTAR_TEST_CASE(test_concurrent_calls) {
+    return with_env([] (rpc_env& env) {
+        env.register_handler(5, [] (int x) {
+            return seastar::sleep(std::chrono::milliseconds(2)).then([x] {
+                return make_ready_future<int>(x * x);
+            });
+        });
+        auto c_h = env.make_client(); auto& c = *c_h;
+        auto call = env.proto.make_client<int (int)>(5);
+        std::vector<future<int>> fs;
+        for (int i = 0; i < 32; ++i) {
+            fs.push_back(call(c, i));
+        }
+        int got = 0;
+        for (int i = 0; i < 32; ++i) {
+            got += fs[i].get();
+        }
+        // sum_{i=0..31} i^2 = 31*32*63/6 = 10416
+        BOOST_REQUIRE_EQUAL(got, 10416);
+        c.stop().get();
+    });
+}
+
+SEASTAR_TEST_CASE(test_unregister_handler) {
+    return with_env([] (rpc_env& env) {
+        env.register_handler(6, [] () { return make_ready_future<int>(7); });
+        auto c_h = env.make_client(); auto& c = *c_h;
+        auto call = env.proto.make_client<int ()>(6);
+        BOOST_REQUIRE_EQUAL(call(c).get(), 7);
+        // pop the handler so env.stop() does not double-unregister
+        env.handlers.erase(std::find(env.handlers.begin(), env.handlers.end(), 6));
+        env.proto.unregister_handler(6).get();
+        BOOST_REQUIRE_THROW(call(c).get(), rpc::unknown_verb_error);
+        c.stop().get();
+    });
+}
+
+SEASTAR_TEST_CASE(test_message_too_big) {
+    rpc::resource_limits rl{0, 1, 100};
+    return with_env([] (rpc_env& env) {
+        bool handler_ran = false;
+        env.register_handler(7, [&handler_ran] (sstring) {
+            handler_ran = true;
+        });
+        auto c_h = env.make_client(); auto& c = *c_h;
+        auto call = env.proto.make_client<void (sstring)>(7);
+        // Message size > max_memory => server must reject without invoking handler.
+        BOOST_CHECK_THROW(call(c, uninitialized_string(101)).get(), std::runtime_error);
+        BOOST_REQUIRE(!handler_ran);
+        c.stop().get();
+    }, rl);
+}
+
+SEASTAR_TEST_CASE(test_client_stop_aborts_pending) {
+    return with_env([] (rpc_env& env) {
+        // Handler blocks on an explicit promise (released in finally) rather
+        // than a long sleep, so teardown is instant once the client stops.
+        auto release = make_lw_shared<promise<>>();
+        env.register_handler(8, [release] () {
+            return release->get_future().then([] { return make_ready_future<int>(0); });
+        });
+        auto c_h = env.make_client(); auto& c = *c_h;
+        auto call = env.proto.make_client<int ()>(8);
+        auto f = call(c);
+        seastar::sleep(std::chrono::milliseconds(20)).get();  // let the call reach the server
+        c.stop().get();
+        BOOST_CHECK_THROW(f.get(), std::exception);
+        release->set_value();  // let the server-side handler finish so stop() drains fast
+    });
+}
+
+SEASTAR_TEST_CASE(test_cancel_send) {
+    using namespace std::chrono_literals;
+    return with_env([] (rpc_env& env) {
+        bool ran = false;
+        env.register_handler(9, [&ran] {
+            ran = true;
+            return make_ready_future<>();
+        });
+        auto c_h = env.make_client(); auto& c = *c_h;
+        auto call = env.proto.make_client<void ()>(9);
+        promise<> hold;
+        rpc::cancellable cancel;
+        c.suspend_for_testing(hold);  // block the sender queue
+        auto f = call(c, cancel);
+        cancel.cancel();
+        hold.set_value();
+        BOOST_CHECK_THROW(f.get(), rpc::canceled_error);
+        BOOST_REQUIRE(!ran);
+        c.stop().get();
+    });
+}
+
+SEASTAR_TEST_CASE(test_no_wait_one_way) {
+    return with_env([] (rpc_env& env) {
+        promise<> handler_called;
+        auto fut = handler_called.get_future();
+        env.register_handler(10, [&handler_called] (int x) -> future<rpc::no_wait_type> {
+            if (x == 5) handler_called.set_value();
+            return make_ready_future<rpc::no_wait_type>(rpc::no_wait);
+        });
+        auto c_h = env.make_client(); auto& c = *c_h;
+        auto call = env.proto.make_client<rpc::no_wait_type (int)>(10);
+        call(c, 5).get();           // returns immediately on the wire
+        fut.get();                  // server-side observed the call
+        c.stop().get();
+    });
+}
+
+SEASTAR_TEST_CASE(test_has_handler) {
+    return with_env([] (rpc_env& env) {
+        BOOST_REQUIRE(!env.proto.has_handlers());
+        env.register_handler(11, [] { return make_ready_future<>(); });
+        BOOST_REQUIRE(env.proto.has_handlers());
+        BOOST_REQUIRE(env.proto.has_handler(11));
+        BOOST_REQUIRE(!env.proto.has_handler(12));
+    });
+}
+
+SEASTAR_TEST_CASE(test_isolation_cookie_invokes_resolver) {
+    auto seen = make_lw_shared<int>(0);
+    rpc::resource_limits rl;
+    rl.isolate_connection = [seen] (sstring cookie) {
+        if (cookie == sstring("special")) (*seen)++;
+        return rpc::isolation_config{};
+    };
+    return with_env([] (rpc_env& env) {
+        env.register_handler(13, [] (int x) { return make_ready_future<int>(x); });
+        rpc::client_options co;
+        co.isolation_cookie = "special";
+        auto c_h = env.make_client(co); auto& c = *c_h;
+        auto call = env.proto.make_client<int (int)>(13);
+        BOOST_REQUIRE_EQUAL(call(c, 9).get(), 9);
+        c.stop().get();
+    }, std::move(rl)).then([seen] {
+        BOOST_REQUIRE_GE(*seen, 1);
+    });
+}
+
+SEASTAR_TEST_CASE(test_stats_counted) {
+    return with_env([] (rpc_env& env) {
+        env.register_handler(14, [] (int x) { return make_ready_future<int>(x + 1); });
+        auto c_h = env.make_client(); auto& c = *c_h;
+        auto call = env.proto.make_client<int (int)>(14);
+        for (int i = 0; i < 5; ++i) {
+            BOOST_REQUIRE_EQUAL(call(c, i).get(), i + 1);
+        }
+        auto s = c.get_stats();
+        BOOST_REQUIRE_GE(s.sent_messages, 5u);
+        BOOST_REQUIRE_GE(s.replied, 5u);
+        c.stop().get();
+    });
+}
+
+SEASTAR_TEST_CASE(test_reregister_throws) {
+    return with_env([] (rpc_env& env) {
+        env.register_handler(15, [] { return make_ready_future<>(); });
+        BOOST_CHECK_THROW(
+            env.proto.register_handler(15, [] { return make_ready_future<>(); }),
+            std::runtime_error);
+    });
+}
+
+SEASTAR_TEST_CASE(test_two_clients_same_server) {
+    return with_env([] (rpc_env& env) {
+        env.register_handler(16, [] (int x) { return make_ready_future<int>(x * 2); });
+        auto c1_h = env.make_client(); auto& c1 = *c1_h;
+        auto c2_h = env.make_client(); auto& c2 = *c2_h;
+        auto call = env.proto.make_client<int (int)>(16);
+        BOOST_REQUIRE_EQUAL(call(c1, 3).get(), 6);
+        BOOST_REQUIRE_EQUAL(call(c2, 5).get(), 10);
+        c1.stop().get();
+        c2.stop().get();
+    });
+}
+
+// ============================================================
+// Extended tests
+// ============================================================
+
+// Minimal LZ4 compressor factory (mirrors the one in rpc_test.cc).
+struct test_cfactory : rpc::compressor::factory {
+    mutable int negotiated = 0;
+    const sstring _name = "LZ4";
+    const sstring& supported() const override { return _name; }
+    std::unique_ptr<rpc::compressor> negotiate(sstring feature, bool is_server) const override {
+        if (feature == _name) {
+            negotiated++;
+            return std::make_unique<rpc::lz4_compressor>();
+        }
+        return nullptr;
+    }
+};
+
+SEASTAR_TEST_CASE(test_send_timeout) {
+    return with_env([] (rpc_env& env) {
+        // Handler blocks until released; the client's short timeout must fire
+        // first. Releasing in finally keeps teardown instant.
+        auto release = make_lw_shared<promise<>>();
+        env.register_handler(20, [release] (int v) {
+            return release->get_future().then([v] { return make_ready_future<int>(v); });
+        });
+        auto c_h = env.make_client(); auto& c = *c_h;
+        auto call = env.proto.make_client<int (int)>(20);
+        auto start = std::chrono::steady_clock::now();
+        BOOST_CHECK_THROW(call(c, std::chrono::milliseconds(100), 1).get(),
+                          rpc::timeout_error);
+        BOOST_REQUIRE(std::chrono::steady_clock::now() - start < std::chrono::seconds(2));
+        c.stop().get();
+        release->set_value();
+    });
+}
+
+SEASTAR_TEST_CASE(test_scheduling_group_per_handler) {
+    return with_env([] (rpc_env& env) {
+        auto sg = create_scheduling_group("rpc_test_sg", 100).get();
+        auto cleanup = defer([sg] () noexcept { destroy_scheduling_group(sg).get(); });
+        env.register_handler(21, sg, [] () {
+            return make_ready_future<unsigned>(
+                internal::scheduling_group_index(current_scheduling_group()));
+        });
+        auto c_h = env.make_client(); auto& c = *c_h;
+        auto call = env.proto.make_client<unsigned ()>(21);
+        BOOST_REQUIRE_EQUAL(call(c).get(), internal::scheduling_group_index(sg));
+        c.stop().get();
+    });
+}
+
+SEASTAR_TEST_CASE(test_abort_connection_from_handler) {
+    return with_env([] (rpc_env& env) {
+        auto arrived = make_lw_shared<int>(0);
+        env.register_handler(22, [arrived] (rpc::client_info& ci, int x) {
+            BOOST_REQUIRE_EQUAL(x, (*arrived)++);
+            if (*arrived == 2) {
+                ci.server.abort_connection(ci.conn_id);
+            }
+            return 0;
+        });
+        auto c_h = env.make_client(); auto& c = *c_h;
+        auto call = env.proto.make_client<int (int)>(22);
+        BOOST_REQUIRE_EQUAL(call(c, 0).get(), 0);
+        BOOST_CHECK_THROW(call(c, 1).get(), rpc::closed_error);
+        BOOST_CHECK_THROW(call(c, 2).get(), rpc::closed_error);
+        BOOST_REQUIRE_EQUAL(*arrived, 2);
+        c.stop().get();
+    });
+}
+
+SEASTAR_TEST_CASE(test_client_info_auxiliary) {
+    return with_env([] (rpc_env& env) {
+        rpc::client_info info{.server{env.server}, .conn_id{rpc::connection_id::make_id(0, 0)}};
+        const rpc::client_info& cinfo = info;
+        info.attach_auxiliary("k", 7);
+        BOOST_REQUIRE_EQUAL(cinfo.retrieve_auxiliary<int>("k"), 7);
+        info.retrieve_auxiliary<int>("k") = 9;
+        BOOST_REQUIRE_EQUAL(cinfo.retrieve_auxiliary<int>("k"), 9);
+        BOOST_REQUIRE_EQUAL(cinfo.retrieve_auxiliary_opt<int>("missing"),
+                            static_cast<const int*>(nullptr));
+    });
+}
+
+SEASTAR_TEST_CASE(test_connection_id_format) {
+    rpc::connection_id cid = rpc::connection_id::make_id(0x123, 1);
+    BOOST_REQUIRE_EQUAL(format("{}", cid), sstring("1230001"));
+    return make_ready_future<>();
+}
+
+SEASTAR_TEST_CASE(test_multiple_distinct_verbs) {
+    return with_env([] (rpc_env& env) {
+        env.register_handler(30, [] (int a, int b) { return make_ready_future<int>(a + b); });
+        env.register_handler(31, [] (int a, int b) { return make_ready_future<int>(a * b); });
+        env.register_handler(32, [] (sstring s) { return make_ready_future<sstring>(s + s); });
+        auto c_h = env.make_client(); auto& c = *c_h;
+        auto add = env.proto.make_client<int (int, int)>(30);
+        auto mul = env.proto.make_client<int (int, int)>(31);
+        auto dup = env.proto.make_client<sstring (sstring)>(32);
+        BOOST_REQUIRE_EQUAL(add(c, 4, 5).get(), 9);
+        BOOST_REQUIRE_EQUAL(mul(c, 4, 5).get(), 20);
+        BOOST_REQUIRE_EQUAL(dup(c, sstring("ab")).get(), sstring("abab"));
+        c.stop().get();
+    });
+}
+
+SEASTAR_TEST_CASE(test_large_payload_roundtrip) {
+    return with_env([] (rpc_env& env) {
+        env.register_handler(33, [] (sstring s) {
+            return make_ready_future<uint64_t>(s.size());
+        });
+        auto c_h = env.make_client(); auto& c = *c_h;
+        auto call = env.proto.make_client<uint64_t (sstring)>(33);
+        sstring big(256 * 1024, 'x');
+        BOOST_REQUIRE_EQUAL(call(c, big).get(), big.size());
+        c.stop().get();
+    });
+}
+
+SEASTAR_TEST_CASE(test_tuple_return) {
+    return with_env([] (rpc_env& env) {
+        env.register_handler(34, [] (int x) {
+            return make_ready_future<rpc::tuple<int, sstring>>(
+                rpc::tuple<int, sstring>(x + 1, sstring("ok")));
+        });
+        auto c_h = env.make_client(); auto& c = *c_h;
+        auto call = env.proto.make_client<rpc::tuple<int, sstring> (int)>(34);
+        auto [n, s] = call(c, 41).get();
+        BOOST_REQUIRE_EQUAL(n, 42);
+        BOOST_REQUIRE_EQUAL(s, sstring("ok"));
+        c.stop().get();
+    });
+}
+
+SEASTAR_TEST_CASE(test_compression_lz4_roundtrip) {
+    auto factory = make_lw_shared<test_cfactory>();
+    rpc::server_options so;
+    so.compressor_factory = factory.get();
+    return with_env([factory] (rpc_env& env) {
+        env.register_handler(35, [] (sstring s) {
+            return make_ready_future<sstring>(s + sstring("-z"));
+        });
+        rpc::client_options co;
+        co.compressor_factory = factory.get();
+        auto c_h = env.make_client(co); auto& c = *c_h;
+        auto call = env.proto.make_client<sstring (sstring)>(35);
+        BOOST_REQUIRE_EQUAL(call(c, sstring("payload")).get(), sstring("payload-z"));
+        c.stop().get();
+    }, {}, std::move(so)).then([factory] {
+        // Both client and server must have negotiated the LZ4 compressor.
+        BOOST_REQUIRE_GE(factory->negotiated, 2);
+    });
+}
+
+SEASTAR_TEST_CASE(test_server_shutdown_then_stop) {
+    return with_env([] (rpc_env& env) {
+        env.register_handler(36, [] (int x) { return make_ready_future<int>(x); });
+        auto c_h = env.make_client(); auto& c = *c_h;
+        auto call = env.proto.make_client<int (int)>(36);
+        BOOST_REQUIRE_EQUAL(call(c, 1).get(), 1);
+        // shutdown() must precede stop(); after it, new calls must fail.
+        env.server.shutdown().get();
+        BOOST_CHECK_THROW(call(c, 2).get(), std::exception);
+        c.stop().get();
+    });
+}
+
+SEASTAR_TEST_CASE(test_many_sequential_calls_ordering) {
+    return with_env([] (rpc_env& env) {
+        env.register_handler(37, [] (int x) { return make_ready_future<int>(x); });
+        auto c_h = env.make_client(); auto& c = *c_h;
+        auto call = env.proto.make_client<int (int)>(37);
+        for (int i = 0; i < 200; ++i) {
+            BOOST_REQUIRE_EQUAL(call(c, i).get(), i);
+        }
+        c.stop().get();
+    });
+}
+
+SEASTAR_TEST_CASE(test_handler_receives_client_info) {
+    return with_env([] (rpc_env& env) {
+        // The handler just records that it received a client_info and the
+        // argument; never assert inside a handler (a failing BOOST_* there
+        // aborts the process instead of failing the test).
+        auto got_arg = make_lw_shared<int>(-1);
+        env.register_handler(38, [got_arg] (const rpc::client_info& ci, int x) {
+            (void)ci;            // loopback addr family is unspecified; just observe it exists
+            *got_arg = x;
+            return make_ready_future<int>(x + 1);
+        });
+        auto c_h = env.make_client(); auto& c = *c_h;
+        auto call = env.proto.make_client<int (int)>(38);
+        BOOST_REQUIRE_EQUAL(call(c, 7).get(), 8);
+        BOOST_REQUIRE_EQUAL(*got_arg, 7);
+        c.stop().get();
+    });
+}
+
+// Bigger stress test: several clients, many concurrent calls, large payloads,
+// each response verified against a locally-computed checksum.
+SEASTAR_TEST_CASE(test_stress_many_clients_large_data) {
+    return with_env([] (rpc_env& env) {
+        constexpr unsigned n_clients = 8;
+        constexpr unsigned calls_per_client = 60;
+        constexpr size_t payload_size = 64 * 1024;
+
+        // Verb: fold the payload into a checksum mixed with `seed`, and also
+        // echo the length back, so the client can validate both.
+        env.register_handler(40, [] (uint64_t seed, sstring data) {
+            uint64_t h = seed;
+            for (unsigned char ch : data) {
+                h = h * 1099511628211ull + ch;   // FNV-ish mix
+            }
+            return make_ready_future<rpc::tuple<uint64_t, uint64_t>>(
+                rpc::tuple<uint64_t, uint64_t>(h, data.size()));
+        });
+
+        auto checksum = [] (uint64_t seed, const sstring& data) {
+            uint64_t h = seed;
+            for (unsigned char ch : data) {
+                h = h * 1099511628211ull + ch;
+            }
+            return h;
+        };
+
+        // Spin up the clients.
+        std::vector<std::unique_ptr<test_proto::client>> clients;
+        for (unsigned i = 0; i < n_clients; ++i) {
+            clients.push_back(env.make_client());
+        }
+
+        auto call = env.proto.make_client<rpc::tuple<uint64_t, uint64_t> (uint64_t, sstring)>(40);
+        auto total_ok = make_lw_shared<uint64_t>(0);
+
+        // Each client fires `calls_per_client` calls concurrently; all clients
+        // run in parallel.
+        parallel_for_each(std::views::iota(0u, n_clients), [&] (unsigned ci) {
+            return parallel_for_each(std::views::iota(0u, calls_per_client), [&, ci] (unsigned k) {
+                uint64_t seed = (uint64_t(ci) << 32) | k;
+                // Distinct, non-trivial payload per (client, call).
+                sstring payload(payload_size, char('A' + ((ci + k) % 26)));
+                for (size_t p = 0; p < payload.size(); p += 997) {
+                    payload[p] = char('0' + (p % 10));
+                }
+                uint64_t expected = checksum(seed, payload);
+                return call(*clients[ci], seed, std::move(payload)).then(
+                        [expected, total_ok] (rpc::tuple<uint64_t, uint64_t> r) {
+                    auto [h, len] = r;
+                    BOOST_REQUIRE_EQUAL(h, expected);
+                    BOOST_REQUIRE_EQUAL(len, uint64_t(64 * 1024));
+                    ++*total_ok;
+                });
+            });
+        }).get();
+
+        BOOST_REQUIRE_EQUAL(*total_ok, uint64_t(n_clients) * calls_per_client);
+
+        for (auto& c : clients) {
+            c->stop().get();
+        }
+    });
+}

--- a/tests/unit/rpc_test_body_tcp.inc.hh
+++ b/tests/unit/rpc_test_body_tcp.inc.hh
@@ -1,0 +1,650 @@
+/*
+ * Shared body for rpc_modified and rpc_quic unit tests.
+ *
+ * The including TU must already have included exactly one of:
+ *   <seastar/rpc/rpc_modified.hh>
+ *   <seastar/rpc/rpc_quic.hh>
+ * (both expose the seastar::rpc::* surface used here, but define
+ *  conflicting symbols, so they cannot be linked together.)
+ */
+
+#include "loopback_socket.hh"
+
+#include <seastar/rpc/rpc_types.hh>
+#include <seastar/rpc/lz4_compressor.hh>
+#include <seastar/rpc/multi_algo_compressor_factory.hh>
+#include <seastar/core/scheduling.hh>
+#include <seastar/testing/test_case.hh>
+#include <seastar/testing/thread_test_case.hh>
+#include <seastar/core/sleep.hh>
+#include <seastar/core/thread.hh>
+#include <seastar/core/loop.hh>
+#include <seastar/core/coroutine.hh>
+#include <seastar/util/closeable.hh>
+#include <seastar/util/defer.hh>
+#include <seastar/util/log.hh>
+
+using namespace seastar;
+
+// ---------- minimal serializer (int / sstring) ----------
+
+struct serializer {};
+
+template <typename T, typename Output>
+inline void write_arith(Output& out, T v) {
+    out.write(reinterpret_cast<const char*>(&v), sizeof(T));
+}
+
+template <typename T, typename Input>
+inline T read_arith(Input& in) {
+    T v;
+    in.read(reinterpret_cast<char*>(&v), sizeof(T));
+    return v;
+}
+
+template <typename Output> inline void write(serializer, Output& o, int32_t v) { write_arith(o, v); }
+template <typename Output> inline void write(serializer, Output& o, uint32_t v) { write_arith(o, v); }
+template <typename Output> inline void write(serializer, Output& o, int64_t v) { write_arith(o, v); }
+template <typename Output> inline void write(serializer, Output& o, uint64_t v) { write_arith(o, v); }
+template <typename Input> inline int32_t  read(serializer, Input& i, rpc::type<int32_t>)  { return read_arith<int32_t>(i); }
+template <typename Input> inline uint32_t read(serializer, Input& i, rpc::type<uint32_t>) { return read_arith<uint32_t>(i); }
+template <typename Input> inline int64_t  read(serializer, Input& i, rpc::type<int64_t>)  { return read_arith<int64_t>(i); }
+template <typename Input> inline uint64_t read(serializer, Input& i, rpc::type<uint64_t>) { return read_arith<uint64_t>(i); }
+
+template <typename Output>
+inline void write(serializer, Output& o, const sstring& v) {
+    write_arith(o, uint32_t(v.size()));
+    o.write(v.c_str(), v.size());
+}
+template <typename Input>
+inline sstring read(serializer, Input& in, rpc::type<sstring>) {
+    auto sz = read_arith<uint32_t>(in);
+    sstring s = uninitialized_string(sz);
+    in.read(s.data(), sz);
+    return s;
+}
+
+using test_proto = rpc::protocol<serializer>;
+
+// ---------- loopback wiring ----------
+
+class lb_socket_impl final : public ::net::socket_impl {
+    loopback_socket_impl _socket;
+public:
+    explicit lb_socket_impl(loopback_connection_factory& f) : _socket(f, nullptr) {}
+    future<connected_socket> connect(socket_address sa, socket_address local, transport proto = transport::TCP) override {
+        return _socket.connect(sa, local, proto);
+    }
+    void set_reuseaddr(bool) override {}
+    bool get_reuseaddr() const override { return false; }
+    void shutdown() override { _socket.shutdown(); }
+};
+
+// Hand-rolled environment that mirrors rpc_test_env, but on a single shard
+// (sharded<> is overkill for our smoke tests and complicates teardown when
+// the underlying RPC implementation is buggy).
+struct rpc_env {
+    // The test server lives on shard 0 only; pin the loopback factory to 1
+    // shard so connections aren't round-robined to shards that have no server
+    // (otherwise -c2+ would hang on connect).
+    loopback_connection_factory lcf{1};
+    test_proto proto;
+    test_proto::server server;
+    std::vector<int> handlers;
+
+    rpc_env(rpc::resource_limits rl = {}, rpc::server_options so = {})
+        : proto(serializer{})
+        , server(proto, so, lcf.get_server_socket(), rl)
+    {}
+
+    ~rpc_env() = default;
+
+    seastar::socket make_socket() {
+        return seastar::socket(std::make_unique<lb_socket_impl>(lcf));
+    }
+
+    template <typename Func>
+    void register_handler(int t, Func&& f) {
+        proto.register_handler(t, std::forward<Func>(f));
+        handlers.push_back(t);
+    }
+
+    template <typename Func>
+    void register_handler(int t, scheduling_group sg, Func&& f) {
+        proto.register_handler(t, sg, std::forward<Func>(f));
+        handlers.push_back(t);
+    }
+
+    future<> stop() {
+        std::vector<int> hs = std::move(handlers);
+        return parallel_for_each(hs, [this] (int t) {
+            return proto.unregister_handler(t);
+        }).finally([this] {
+            return server.stop();
+        }).finally([this] {
+            return lcf.destroy_all_shards();
+        });
+    }
+};
+
+// Helper that owns env + (optionally) a client and tears down in the right order.
+template <typename Body>
+future<> with_env(Body&& body, rpc::resource_limits rl = {}, rpc::server_options so = {}) {
+    return seastar::async([body = std::forward<Body>(body), rl = std::move(rl), so = std::move(so)] () mutable {
+        auto env = std::make_unique<rpc_env>(rl, so);
+        std::exception_ptr ep;
+        try {
+            body(*env);
+        } catch (...) {
+            ep = std::current_exception();
+        }
+        env->stop().get();
+        if (ep) { std::rethrow_exception(ep); }
+    });
+}
+
+// ============================================================
+// Tests
+// ============================================================
+
+SEASTAR_TEST_CASE(test_basic_call) {
+    return with_env([] (rpc_env& env) {
+        env.register_handler(1, [] (int a, int b) {
+            return make_ready_future<int>(a + b);
+        });
+        test_proto::client c(env.proto, {}, env.make_socket(), ipv4_addr());
+        auto sum = env.proto.make_client<int (int, int)>(1);
+        BOOST_REQUIRE_EQUAL(sum(c, 2, 3).get(), 5);
+        BOOST_REQUIRE_EQUAL(sum(c, -7, 7).get(), 0);
+        c.stop().get();
+    });
+}
+
+SEASTAR_TEST_CASE(test_void_return) {
+    return with_env([] (rpc_env& env) {
+        bool called = false;
+        env.register_handler(2, [&called] (int x) {
+            called = (x == 42);
+            return make_ready_future<>();
+        });
+        test_proto::client c(env.proto, {}, env.make_socket(), ipv4_addr());
+        auto call = env.proto.make_client<void (int)>(2);
+        call(c, 42).get();
+        BOOST_REQUIRE(called);
+        c.stop().get();
+    });
+}
+
+SEASTAR_TEST_CASE(test_string_payload) {
+    return with_env([] (rpc_env& env) {
+        env.register_handler(3, [] (sstring s) {
+            return make_ready_future<sstring>(s + sstring("!"));
+        });
+        test_proto::client c(env.proto, {}, env.make_socket(), ipv4_addr());
+        auto call = env.proto.make_client<sstring (sstring)>(3);
+        BOOST_REQUIRE_EQUAL(call(c, sstring("hi")).get(), sstring("hi!"));
+        c.stop().get();
+    });
+}
+
+SEASTAR_TEST_CASE(test_remote_verb_throws) {
+    return with_env([] (rpc_env& env) {
+        env.register_handler(4, [] () -> future<int> {
+            throw std::runtime_error("boom");
+        });
+        test_proto::client c(env.proto, {}, env.make_socket(), ipv4_addr());
+        auto call = env.proto.make_client<int ()>(4);
+        BOOST_REQUIRE_THROW(call(c).get(), rpc::remote_verb_error);
+        c.stop().get();
+    });
+}
+
+SEASTAR_TEST_CASE(test_unknown_verb) {
+    return with_env([] (rpc_env& env) {
+        test_proto::client c(env.proto, {}, env.make_socket(), ipv4_addr());
+        auto call = env.proto.make_client<int ()>(99);
+        BOOST_REQUIRE_THROW(call(c).get(), rpc::unknown_verb_error);
+        c.stop().get();
+    });
+}
+
+SEASTAR_TEST_CASE(test_concurrent_calls) {
+    return with_env([] (rpc_env& env) {
+        env.register_handler(5, [] (int x) {
+            return seastar::sleep(std::chrono::milliseconds(2)).then([x] {
+                return make_ready_future<int>(x * x);
+            });
+        });
+        test_proto::client c(env.proto, {}, env.make_socket(), ipv4_addr());
+        auto call = env.proto.make_client<int (int)>(5);
+        std::vector<future<int>> fs;
+        for (int i = 0; i < 32; ++i) {
+            fs.push_back(call(c, i));
+        }
+        int got = 0;
+        for (int i = 0; i < 32; ++i) {
+            got += fs[i].get();
+        }
+        // sum_{i=0..31} i^2 = 31*32*63/6 = 10416
+        BOOST_REQUIRE_EQUAL(got, 10416);
+        c.stop().get();
+    });
+}
+
+SEASTAR_TEST_CASE(test_unregister_handler) {
+    return with_env([] (rpc_env& env) {
+        env.register_handler(6, [] () { return make_ready_future<int>(7); });
+        test_proto::client c(env.proto, {}, env.make_socket(), ipv4_addr());
+        auto call = env.proto.make_client<int ()>(6);
+        BOOST_REQUIRE_EQUAL(call(c).get(), 7);
+        // pop the handler so env.stop() does not double-unregister
+        env.handlers.erase(std::find(env.handlers.begin(), env.handlers.end(), 6));
+        env.proto.unregister_handler(6).get();
+        BOOST_REQUIRE_THROW(call(c).get(), rpc::unknown_verb_error);
+        c.stop().get();
+    });
+}
+
+SEASTAR_TEST_CASE(test_message_too_big) {
+    rpc::resource_limits rl{0, 1, 100};
+    return with_env([] (rpc_env& env) {
+        bool handler_ran = false;
+        env.register_handler(7, [&handler_ran] (sstring) {
+            handler_ran = true;
+        });
+        test_proto::client c(env.proto, {}, env.make_socket(), ipv4_addr());
+        auto call = env.proto.make_client<void (sstring)>(7);
+        // Message size > max_memory => server must reject without invoking handler.
+        BOOST_CHECK_THROW(call(c, uninitialized_string(101)).get(), std::runtime_error);
+        BOOST_REQUIRE(!handler_ran);
+        c.stop().get();
+    }, rl);
+}
+
+SEASTAR_TEST_CASE(test_client_stop_aborts_pending) {
+    return with_env([] (rpc_env& env) {
+        // Handler blocks on an explicit promise (released in finally) rather
+        // than a long sleep, so teardown is instant once the client stops.
+        auto release = make_lw_shared<promise<>>();
+        env.register_handler(8, [release] () {
+            return release->get_future().then([] { return make_ready_future<int>(0); });
+        });
+        test_proto::client c(env.proto, {}, env.make_socket(), ipv4_addr());
+        auto call = env.proto.make_client<int ()>(8);
+        auto f = call(c);
+        seastar::sleep(std::chrono::milliseconds(20)).get();  // let the call reach the server
+        c.stop().get();
+        BOOST_CHECK_THROW(f.get(), std::exception);
+        release->set_value();  // let the server-side handler finish so stop() drains fast
+    });
+}
+
+SEASTAR_TEST_CASE(test_cancel_send) {
+    using namespace std::chrono_literals;
+    return with_env([] (rpc_env& env) {
+        bool ran = false;
+        env.register_handler(9, [&ran] {
+            ran = true;
+            return make_ready_future<>();
+        });
+        test_proto::client c(env.proto, {}, env.make_socket(), ipv4_addr());
+        auto call = env.proto.make_client<void ()>(9);
+        promise<> hold;
+        rpc::cancellable cancel;
+        c.suspend_for_testing(hold);  // block the sender queue
+        auto f = call(c, cancel);
+        cancel.cancel();
+        hold.set_value();
+        BOOST_CHECK_THROW(f.get(), rpc::canceled_error);
+        BOOST_REQUIRE(!ran);
+        c.stop().get();
+    });
+}
+
+SEASTAR_TEST_CASE(test_no_wait_one_way) {
+    return with_env([] (rpc_env& env) {
+        promise<> handler_called;
+        auto fut = handler_called.get_future();
+        env.register_handler(10, [&handler_called] (int x) -> future<rpc::no_wait_type> {
+            if (x == 5) handler_called.set_value();
+            return make_ready_future<rpc::no_wait_type>(rpc::no_wait);
+        });
+        test_proto::client c(env.proto, {}, env.make_socket(), ipv4_addr());
+        auto call = env.proto.make_client<rpc::no_wait_type (int)>(10);
+        call(c, 5).get();           // returns immediately on the wire
+        fut.get();                  // server-side observed the call
+        c.stop().get();
+    });
+}
+
+SEASTAR_TEST_CASE(test_has_handler) {
+    return with_env([] (rpc_env& env) {
+        BOOST_REQUIRE(!env.proto.has_handlers());
+        env.register_handler(11, [] { return make_ready_future<>(); });
+        BOOST_REQUIRE(env.proto.has_handlers());
+        BOOST_REQUIRE(env.proto.has_handler(11));
+        BOOST_REQUIRE(!env.proto.has_handler(12));
+    });
+}
+
+SEASTAR_TEST_CASE(test_isolation_cookie_invokes_resolver) {
+    auto seen = make_lw_shared<int>(0);
+    rpc::resource_limits rl;
+    rl.isolate_connection = [seen] (sstring cookie) {
+        if (cookie == sstring("special")) (*seen)++;
+        return rpc::isolation_config{};
+    };
+    return with_env([] (rpc_env& env) {
+        env.register_handler(13, [] (int x) { return make_ready_future<int>(x); });
+        rpc::client_options co;
+        co.isolation_cookie = "special";
+        test_proto::client c(env.proto, co, env.make_socket(), ipv4_addr());
+        auto call = env.proto.make_client<int (int)>(13);
+        BOOST_REQUIRE_EQUAL(call(c, 9).get(), 9);
+        c.stop().get();
+    }, std::move(rl)).then([seen] {
+        BOOST_REQUIRE_GE(*seen, 1);
+    });
+}
+
+SEASTAR_TEST_CASE(test_stats_counted) {
+    return with_env([] (rpc_env& env) {
+        env.register_handler(14, [] (int x) { return make_ready_future<int>(x + 1); });
+        test_proto::client c(env.proto, {}, env.make_socket(), ipv4_addr());
+        auto call = env.proto.make_client<int (int)>(14);
+        for (int i = 0; i < 5; ++i) {
+            BOOST_REQUIRE_EQUAL(call(c, i).get(), i + 1);
+        }
+        auto s = c.get_stats();
+        BOOST_REQUIRE_GE(s.sent_messages, 5u);
+        BOOST_REQUIRE_GE(s.replied, 5u);
+        c.stop().get();
+    });
+}
+
+SEASTAR_TEST_CASE(test_reregister_throws) {
+    return with_env([] (rpc_env& env) {
+        env.register_handler(15, [] { return make_ready_future<>(); });
+        BOOST_CHECK_THROW(
+            env.proto.register_handler(15, [] { return make_ready_future<>(); }),
+            std::runtime_error);
+    });
+}
+
+SEASTAR_TEST_CASE(test_two_clients_same_server) {
+    return with_env([] (rpc_env& env) {
+        env.register_handler(16, [] (int x) { return make_ready_future<int>(x * 2); });
+        test_proto::client c1(env.proto, {}, env.make_socket(), ipv4_addr());
+        test_proto::client c2(env.proto, {}, env.make_socket(), ipv4_addr());
+        auto call = env.proto.make_client<int (int)>(16);
+        BOOST_REQUIRE_EQUAL(call(c1, 3).get(), 6);
+        BOOST_REQUIRE_EQUAL(call(c2, 5).get(), 10);
+        c1.stop().get();
+        c2.stop().get();
+    });
+}
+
+// ============================================================
+// Extended tests
+// ============================================================
+
+// Minimal LZ4 compressor factory (mirrors the one in rpc_test.cc).
+struct test_cfactory : rpc::compressor::factory {
+    mutable int negotiated = 0;
+    const sstring _name = "LZ4";
+    const sstring& supported() const override { return _name; }
+    std::unique_ptr<rpc::compressor> negotiate(sstring feature, bool is_server) const override {
+        if (feature == _name) {
+            negotiated++;
+            return std::make_unique<rpc::lz4_compressor>();
+        }
+        return nullptr;
+    }
+};
+
+SEASTAR_TEST_CASE(test_send_timeout) {
+    return with_env([] (rpc_env& env) {
+        // Handler blocks until released; the client's short timeout must fire
+        // first. Releasing in finally keeps teardown instant.
+        auto release = make_lw_shared<promise<>>();
+        env.register_handler(20, [release] (int v) {
+            return release->get_future().then([v] { return make_ready_future<int>(v); });
+        });
+        test_proto::client c(env.proto, {}, env.make_socket(), ipv4_addr());
+        auto call = env.proto.make_client<int (int)>(20);
+        auto start = std::chrono::steady_clock::now();
+        BOOST_CHECK_THROW(call(c, std::chrono::milliseconds(100), 1).get(),
+                          rpc::timeout_error);
+        BOOST_REQUIRE(std::chrono::steady_clock::now() - start < std::chrono::seconds(2));
+        c.stop().get();
+        release->set_value();
+    });
+}
+
+SEASTAR_TEST_CASE(test_scheduling_group_per_handler) {
+    return with_env([] (rpc_env& env) {
+        auto sg = create_scheduling_group("rpc_test_sg", 100).get();
+        auto cleanup = defer([sg] () noexcept { destroy_scheduling_group(sg).get(); });
+        env.register_handler(21, sg, [] () {
+            return make_ready_future<unsigned>(
+                internal::scheduling_group_index(current_scheduling_group()));
+        });
+        test_proto::client c(env.proto, {}, env.make_socket(), ipv4_addr());
+        auto call = env.proto.make_client<unsigned ()>(21);
+        BOOST_REQUIRE_EQUAL(call(c).get(), internal::scheduling_group_index(sg));
+        c.stop().get();
+    });
+}
+
+SEASTAR_TEST_CASE(test_abort_connection_from_handler) {
+    return with_env([] (rpc_env& env) {
+        auto arrived = make_lw_shared<int>(0);
+        env.register_handler(22, [arrived] (rpc::client_info& ci, int x) {
+            BOOST_REQUIRE_EQUAL(x, (*arrived)++);
+            if (*arrived == 2) {
+                ci.server.abort_connection(ci.conn_id);
+            }
+            return 0;
+        });
+        test_proto::client c(env.proto, {}, env.make_socket(), ipv4_addr());
+        auto call = env.proto.make_client<int (int)>(22);
+        BOOST_REQUIRE_EQUAL(call(c, 0).get(), 0);
+        BOOST_CHECK_THROW(call(c, 1).get(), rpc::closed_error);
+        BOOST_CHECK_THROW(call(c, 2).get(), rpc::closed_error);
+        BOOST_REQUIRE_EQUAL(*arrived, 2);
+        c.stop().get();
+    });
+}
+
+SEASTAR_TEST_CASE(test_client_info_auxiliary) {
+    return with_env([] (rpc_env& env) {
+        rpc::client_info info{.server{env.server}, .conn_id{rpc::connection_id::make_id(0, 0)}};
+        const rpc::client_info& cinfo = info;
+        info.attach_auxiliary("k", 7);
+        BOOST_REQUIRE_EQUAL(cinfo.retrieve_auxiliary<int>("k"), 7);
+        info.retrieve_auxiliary<int>("k") = 9;
+        BOOST_REQUIRE_EQUAL(cinfo.retrieve_auxiliary<int>("k"), 9);
+        BOOST_REQUIRE_EQUAL(cinfo.retrieve_auxiliary_opt<int>("missing"),
+                            static_cast<const int*>(nullptr));
+    });
+}
+
+SEASTAR_TEST_CASE(test_connection_id_format) {
+    rpc::connection_id cid = rpc::connection_id::make_id(0x123, 1);
+    BOOST_REQUIRE_EQUAL(format("{}", cid), sstring("1230001"));
+    return make_ready_future<>();
+}
+
+SEASTAR_TEST_CASE(test_multiple_distinct_verbs) {
+    return with_env([] (rpc_env& env) {
+        env.register_handler(30, [] (int a, int b) { return make_ready_future<int>(a + b); });
+        env.register_handler(31, [] (int a, int b) { return make_ready_future<int>(a * b); });
+        env.register_handler(32, [] (sstring s) { return make_ready_future<sstring>(s + s); });
+        test_proto::client c(env.proto, {}, env.make_socket(), ipv4_addr());
+        auto add = env.proto.make_client<int (int, int)>(30);
+        auto mul = env.proto.make_client<int (int, int)>(31);
+        auto dup = env.proto.make_client<sstring (sstring)>(32);
+        BOOST_REQUIRE_EQUAL(add(c, 4, 5).get(), 9);
+        BOOST_REQUIRE_EQUAL(mul(c, 4, 5).get(), 20);
+        BOOST_REQUIRE_EQUAL(dup(c, sstring("ab")).get(), sstring("abab"));
+        c.stop().get();
+    });
+}
+
+SEASTAR_TEST_CASE(test_large_payload_roundtrip) {
+    return with_env([] (rpc_env& env) {
+        env.register_handler(33, [] (sstring s) {
+            return make_ready_future<uint64_t>(s.size());
+        });
+        test_proto::client c(env.proto, {}, env.make_socket(), ipv4_addr());
+        auto call = env.proto.make_client<uint64_t (sstring)>(33);
+        sstring big(256 * 1024, 'x');
+        BOOST_REQUIRE_EQUAL(call(c, big).get(), big.size());
+        c.stop().get();
+    });
+}
+
+SEASTAR_TEST_CASE(test_tuple_return) {
+    return with_env([] (rpc_env& env) {
+        env.register_handler(34, [] (int x) {
+            return make_ready_future<rpc::tuple<int, sstring>>(
+                rpc::tuple<int, sstring>(x + 1, sstring("ok")));
+        });
+        test_proto::client c(env.proto, {}, env.make_socket(), ipv4_addr());
+        auto call = env.proto.make_client<rpc::tuple<int, sstring> (int)>(34);
+        auto [n, s] = call(c, 41).get();
+        BOOST_REQUIRE_EQUAL(n, 42);
+        BOOST_REQUIRE_EQUAL(s, sstring("ok"));
+        c.stop().get();
+    });
+}
+
+SEASTAR_TEST_CASE(test_compression_lz4_roundtrip) {
+    auto factory = make_lw_shared<test_cfactory>();
+    rpc::server_options so;
+    so.compressor_factory = factory.get();
+    return with_env([factory] (rpc_env& env) {
+        env.register_handler(35, [] (sstring s) {
+            return make_ready_future<sstring>(s + sstring("-z"));
+        });
+        rpc::client_options co;
+        co.compressor_factory = factory.get();
+        test_proto::client c(env.proto, co, env.make_socket(), ipv4_addr());
+        auto call = env.proto.make_client<sstring (sstring)>(35);
+        BOOST_REQUIRE_EQUAL(call(c, sstring("payload")).get(), sstring("payload-z"));
+        c.stop().get();
+    }, {}, std::move(so)).then([factory] {
+        // Both client and server must have negotiated the LZ4 compressor.
+        BOOST_REQUIRE_GE(factory->negotiated, 2);
+    });
+}
+
+SEASTAR_TEST_CASE(test_server_shutdown_then_stop) {
+    return with_env([] (rpc_env& env) {
+        env.register_handler(36, [] (int x) { return make_ready_future<int>(x); });
+        test_proto::client c(env.proto, {}, env.make_socket(), ipv4_addr());
+        auto call = env.proto.make_client<int (int)>(36);
+        BOOST_REQUIRE_EQUAL(call(c, 1).get(), 1);
+        // shutdown() must precede stop(); after it, new calls must fail.
+        env.server.shutdown().get();
+        BOOST_CHECK_THROW(call(c, 2).get(), std::exception);
+        c.stop().get();
+    });
+}
+
+SEASTAR_TEST_CASE(test_many_sequential_calls_ordering) {
+    return with_env([] (rpc_env& env) {
+        env.register_handler(37, [] (int x) { return make_ready_future<int>(x); });
+        test_proto::client c(env.proto, {}, env.make_socket(), ipv4_addr());
+        auto call = env.proto.make_client<int (int)>(37);
+        for (int i = 0; i < 200; ++i) {
+            BOOST_REQUIRE_EQUAL(call(c, i).get(), i);
+        }
+        c.stop().get();
+    });
+}
+
+SEASTAR_TEST_CASE(test_handler_receives_client_info) {
+    return with_env([] (rpc_env& env) {
+        // The handler just records that it received a client_info and the
+        // argument; never assert inside a handler (a failing BOOST_* there
+        // aborts the process instead of failing the test).
+        auto got_arg = make_lw_shared<int>(-1);
+        env.register_handler(38, [got_arg] (const rpc::client_info& ci, int x) {
+            (void)ci;            // loopback addr family is unspecified; just observe it exists
+            *got_arg = x;
+            return make_ready_future<int>(x + 1);
+        });
+        test_proto::client c(env.proto, {}, env.make_socket(), ipv4_addr());
+        auto call = env.proto.make_client<int (int)>(38);
+        BOOST_REQUIRE_EQUAL(call(c, 7).get(), 8);
+        BOOST_REQUIRE_EQUAL(*got_arg, 7);
+        c.stop().get();
+    });
+}
+
+// Bigger stress test: several clients, many concurrent calls, large payloads,
+// each response verified against a locally-computed checksum.
+SEASTAR_TEST_CASE(test_stress_many_clients_large_data) {
+    return with_env([] (rpc_env& env) {
+        constexpr unsigned n_clients = 8;
+        constexpr unsigned calls_per_client = 60;
+        constexpr size_t payload_size = 64 * 1024;
+
+        // Verb: fold the payload into a checksum mixed with `seed`, and also
+        // echo the length back, so the client can validate both.
+        env.register_handler(40, [] (uint64_t seed, sstring data) {
+            uint64_t h = seed;
+            for (unsigned char ch : data) {
+                h = h * 1099511628211ull + ch;   // FNV-ish mix
+            }
+            return make_ready_future<rpc::tuple<uint64_t, uint64_t>>(
+                rpc::tuple<uint64_t, uint64_t>(h, data.size()));
+        });
+
+        auto checksum = [] (uint64_t seed, const sstring& data) {
+            uint64_t h = seed;
+            for (unsigned char ch : data) {
+                h = h * 1099511628211ull + ch;
+            }
+            return h;
+        };
+
+        // Spin up the clients.
+        std::vector<std::unique_ptr<test_proto::client>> clients;
+        for (unsigned i = 0; i < n_clients; ++i) {
+            clients.push_back(std::make_unique<test_proto::client>(
+                env.proto, rpc::client_options{}, env.make_socket(), ipv4_addr()));
+        }
+
+        auto call = env.proto.make_client<rpc::tuple<uint64_t, uint64_t> (uint64_t, sstring)>(40);
+        auto total_ok = make_lw_shared<uint64_t>(0);
+
+        // Each client fires `calls_per_client` calls concurrently; all clients
+        // run in parallel.
+        parallel_for_each(std::views::iota(0u, n_clients), [&] (unsigned ci) {
+            return parallel_for_each(std::views::iota(0u, calls_per_client), [&, ci] (unsigned k) {
+                uint64_t seed = (uint64_t(ci) << 32) | k;
+                // Distinct, non-trivial payload per (client, call).
+                sstring payload(payload_size, char('A' + ((ci + k) % 26)));
+                for (size_t p = 0; p < payload.size(); p += 997) {
+                    payload[p] = char('0' + (p % 10));
+                }
+                uint64_t expected = checksum(seed, payload);
+                return call(*clients[ci], seed, std::move(payload)).then(
+                        [expected, total_ok] (rpc::tuple<uint64_t, uint64_t> r) {
+                    auto [h, len] = r;
+                    BOOST_REQUIRE_EQUAL(h, expected);
+                    BOOST_REQUIRE_EQUAL(len, uint64_t(64 * 1024));
+                    ++*total_ok;
+                });
+            });
+        }).get();
+
+        BOOST_REQUIRE_EQUAL(*total_ok, uint64_t(n_clients) * calls_per_client);
+
+        for (auto& c : clients) {
+            c->stop().get();
+        }
+    });
+}


### PR DESCRIPTION
## Summary

This PR adds experimental support for running Seastar RPC over QUIC.

The main idea is to separate the RPC protocol logic from the concrete network transport. Until now, the RPC implementation was tied closely to the TCP socket path. This change introduces a transport layer underneath RPC, so the same higher-level RPC logic can be used with both the existing TCP implementation and the new QUIC-based path.

On the QUIC side, the RPC connection uses QUIC as the underlying transport and sends individual RPC requests over QUIC streams. This allows the RPC layer to take advantage of QUIC’s stream model while keeping the public RPC usage mostly unchanged for callers.

The existing TCP behavior is intended to remain unchanged. To make sure the refactor does not regress the old path, this PR also adds a TCP loopback test suite that exercises the same RPC scenarios independently from QUIC.

## Details

The PR covers the full basic RPC lifecycle over QUIC: establishing client and server connections, negotiating the RPC protocol, sending requests, receiving replies, handling errors, shutting down connections, cancelling calls, and dealing with timeouts. It also keeps support for existing RPC features such as compression, isolation cookies, scheduling groups, `no_wait` calls, large payloads, and multiple concurrent clients.

A new QUIC-backed RPC demo is included to show how the transport is used in practice. The PR also adds benchmark programs that make it possible to compare raw QUIC and the integrated RPC-over-QUIC path in throughput and latency scenarios.

## Testing

This PR adds two parallel RPC test suites:

- one suite runs the refactored RPC implementation over TCP loopback
- the other runs the same kinds of RPC scenarios over a real QUIC/TLS connection

Together, these tests check both that the existing TCP path still works after the refactor and that the new QUIC path behaves correctly end-to-end.